### PR TITLE
295 decouple selection and zoom to this node

### DIFF
--- a/docs/source/key_bindings.rst
+++ b/docs/source/key_bindings.rst
@@ -11,9 +11,11 @@ Napari viewer and layer key bindings and mouse functions
    * - Mouse / Key binding
      - Action
    * - Click on a point or label
-     - Select this node (center view if necessary)
+     - Select this node (centers view if only one node selected)
    * - SHIFT + click on point or label
-     - Add this node to selection
+     - Add this node to selection (does not center view)
+   * - CTRL + click on point or label
+     - Center view on this node (does not change selection)
    * - Mouse drag with point layer selection tool active
      - Select multiple nodes at once
    * - Q
@@ -30,9 +32,11 @@ Tree view key and mouse functions
    * - Mouse / Key binding
      - Action
    * - Click on a node
-     - Select this node (center view if necessary)
+     - Select this node (centers view if only one node selected)
    * - SHIFT + click on a node
-     - Add this node to selection
+     - Add this node to selection (does not center view)
+   * - CTRL + click on a node
+     - Center view on this node (does not change selection)
    * - Scroll
      - Zoom in or out
    * - Scroll + X / Right mouse click + drag horizontally

--- a/docs/source/key_bindings.rst
+++ b/docs/source/key_bindings.rst
@@ -35,7 +35,7 @@ Tree view key and mouse functions
      - Select this node (centers view if only one node selected)
    * - SHIFT + click on a node
      - Add this node to selection (does not center view)
-   * - CTRL + click on a node
+   * - CTRL/CMD + click on a node
      - Center view on this node (does not change selection)
    * - Scroll
      - Zoom in or out

--- a/docs/source/tree_view.rst
+++ b/docs/source/tree_view.rst
@@ -10,7 +10,11 @@ through the motile widget in the tree view, you can open the tree widget from th
 via ``Plugins`` > ``Motile`` > ``Lineage View``.
 
 Clicking on individual nodes in the tree widget or in the napari Points or Labels layer will select that node,
-highlighting it both in the tree view and in the napari layers, and centering the view if necessary.
+highlighting it both in the tree view and in the napari layers. The view is centered on the selected node
+only when a single node is selected. Use ``SHIFT + click`` to add nodes to the selection without centering,
+or ``CTRL + click`` to center the view on a node without changing the selection.
+When multiple nodes are selected, you can cycle through them using the "Next selected node" and
+"Previous selected node" buttons in the Groups widget.
 You can navigate and select nodes in the tree view using the arrow keys (make sure to click on the tree widget first).
 Optionally, you can display only selected lineages in the tree view and/or napari layers (press ``Q`` in the tree widget and/or in the napari viewer).
 If you used a Labels layer as input for tracking, you will also have the option to plot the object sizes (area or volume) in calibrated units

--- a/src/motile_tracker/__main__.py
+++ b/src/motile_tracker/__main__.py
@@ -9,7 +9,7 @@ def main() -> None:
     # Auto-load the motile tracker
     viewer = napari.Viewer()
     main_app = MainApp(viewer)
-    viewer.window.add_dock_widget(main_app)
+    viewer.window.add_dock_widget(main_app, name="Motile Tracker")
 
     # Start napari event loop
     napari.run()

--- a/src/motile_tracker/application_menus/menu_widget.py
+++ b/src/motile_tracker/application_menus/menu_widget.py
@@ -1,9 +1,19 @@
 import napari
-from qtpy.QtWidgets import QScrollArea, QTabWidget, QVBoxLayout
+from qtpy.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
 
 from motile_tracker.application_menus.editing_menu import EditingMenu
 from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
 from motile_tracker.motile.menus.motile_widget import MotileWidget
+
+DOCS_URL = "https://funkelab.github.io/motile_tracker"
+KEYBINDINGS_URL = f"{DOCS_URL}/key_bindings.html"
 
 
 class MenuWidget(QScrollArea):
@@ -19,15 +29,31 @@ class MenuWidget(QScrollArea):
 
         self.tabwidget = QTabWidget()
 
-        self.tabwidget.addTab(motile_widget, "Track with Motile")
+        self.tabwidget.addTab(motile_widget, "Tracking")
         self.tabwidget.addTab(tracks_viewer.tracks_list, "Tracks List")
         self.tabwidget.addTab(editing_widget, "Edit Tracks")
         self.tabwidget.addTab(tracks_viewer.collection_widget, "Groups")
 
-        layout = QVBoxLayout()
-        layout.addWidget(self.tabwidget)
+        # Header with title and help links
+        header_layout = QHBoxLayout()
+        header_layout.setContentsMargins(5, 5, 5, 0)
+        header_label = QLabel(
+            f"<b>Motile Tracker</b> · "
+            f'<a href="{DOCS_URL}"><font color=yellow>Docs</font></a> · '
+            f'<a href="{KEYBINDINGS_URL}"><font color=yellow>Keybindings</font></a>'
+        )
+        header_label.setOpenExternalLinks(True)
+        header_layout.addWidget(header_label)
+        header_layout.addStretch()
 
-        self.setWidget(self.tabwidget)
+        # Container widget with header + tabs
+        container = QWidget()
+        container_layout = QVBoxLayout()
+        container_layout.setContentsMargins(0, 0, 0, 0)
+        container_layout.setSpacing(2)
+        container_layout.addLayout(header_layout)
+        container_layout.addWidget(self.tabwidget)
+        container.setLayout(container_layout)
+
+        self.setWidget(container)
         self.setWidgetResizable(True)
-
-        self.setLayout(layout)

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -139,7 +139,7 @@ class TrackLabels(napari.layers.Labels):
             append = "Shift" in event.modifiers
             jump = "Control" in event.modifiers
             if jump:
-                self.tracks_viewer.tracking_layers.center_view(label)
+                self.tracks_viewer.center_on_node(label)
             else:
                 self.tracks_viewer.selected_nodes.add(label, append)
 

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -137,7 +137,11 @@ class TrackLabels(napari.layers.Labels):
             label is not None and label != 0 and self.colormap.map(label)[-1] != 0
         ):  # check opacity (=visibility) in the colormap
             append = "Shift" in event.modifiers
-            self.tracks_viewer.selected_nodes.add(label, append)
+            jump = "Control" in event.modifiers
+            if jump:
+                self.tracks_viewer.tracking_layers.center_view(label)
+            else:
+                self.tracks_viewer.selected_nodes.add(label, append)
 
     def _get_colormap(self) -> DirectLabelColormap:
         """Get a DirectLabelColormap that maps node ids to their track ids, and then

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -132,7 +132,7 @@ class TrackPoints(napari.layers.Points):
             append = "Shift" in event.modifiers
             jump = "Control" in event.modifiers
             if jump:
-                self.tracks_viewer.tracking_layers.center_view(node_id)
+                self.tracks_viewer.center_on_node(node_id)
             else:
                 self.tracks_viewer.selected_nodes.add(node_id, append)
 

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -130,7 +130,11 @@ class TrackPoints(napari.layers.Points):
         else:
             node_id = self.nodes[point_index]
             append = "Shift" in event.modifiers
-            self.tracks_viewer.selected_nodes.add(node_id, append)
+            jump = "Control" in event.modifiers
+            if jump:
+                self.tracks_viewer.tracking_layers.center_view(node_id)
+            else:
+                self.tracks_viewer.selected_nodes.add(node_id, append)
 
     def set_point_size(self, size: int) -> None:
         """Sets a new default point size.

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -328,12 +328,14 @@ class TreePlot(pg.PlotWidget):
 
     def set_selection(self, selected_nodes: list[Any], plot_type: str) -> None:
         """Set the provided list of nodes to be selected. Increases the size
-        and highlights the outline with blue. Also centers the view
-        if the first selected node is not visible in the current canvas.
+        and highlights the outline with blue.
+
+        Note: Single-node centering is handled separately via the center_node signal
+        from TracksViewer. Multi-node range centering is handled here.
 
         Args:
             selected_nodes (list[Any]): A list of node ids to be selected.
-            feature (str): the feature that is being plotted, either 'tree' or 'area'
+            plot_type (str): the plot type being displayed, either 'tree' or 'feature'
         """
 
         # reset to default size and color to avoid problems with the array lengths
@@ -345,9 +347,7 @@ class TreePlot(pg.PlotWidget):
         )  # just copy the size here to keep the original self.sizes intact
 
         outlines = self.outline_pen.copy()
-        axis_label = (
-            self.feature if plot_type == "feature" else "x_axis_pos"
-        )  # check what is currently being shown, to know how to scale  the view
+        axis_label = self.feature if plot_type == "feature" else "x_axis_pos"
 
         if len(selected_nodes) > 0:
             x_values = []
@@ -366,11 +366,9 @@ class TreePlot(pg.PlotWidget):
                     size[index] += 5
                     outlines[index] = pg.mkPen(color="c", width=2)
 
-            # Center point if a single node is selected, center range if multiple nodes
-            # are selected
-            if len(selected_nodes) == 1:
-                self._center_view(x_axis_value, t)
-            else:
+            # Center range if multiple nodes are selected (single-node centering
+            # is handled by the center_node signal)
+            if len(x_values) > 1:
                 min_x = np.min(x_values)
                 max_x = np.max(x_values)
                 min_t = np.min(t_values)
@@ -403,8 +401,27 @@ class TreePlot(pg.PlotWidget):
         else:
             self.autoRange()
 
+    def center_on_node(self, node_id: int) -> None:
+        """Center the view on a specific node by ID.
+
+        Args:
+            node_id: The node ID to center on.
+        """
+        if not hasattr(self, "track_df") or self.track_df is None:
+            return
+        node_df = self.track_df.loc[self.track_df["node_id"] == node_id]
+        if node_df.empty:
+            return
+        axis_label = self.feature if self.plot_type == "feature" else "x_axis_pos"
+        x_axis_value = node_df[axis_label].values[0]
+        t = node_df["t"].values[0]
+        self._center_view(x_axis_value, t)
+
     def _center_view(self, center_x: int, center_y: int):
-        """Center the Viewbox on given coordinates"""
+        """Center the Viewbox on given coordinates, preserving the current zoom level.
+
+        Only pans if the point is outside the current view.
+        """
 
         if self.view_direction == "horizontal":
             center_x, center_y = (
@@ -425,7 +442,12 @@ class TreePlot(pg.PlotWidget):
         ):
             return
 
-        self.autoRange()
+        # Pan to center the point while preserving current zoom level
+        x_width = x_range[1] - x_range[0]
+        y_width = y_range[1] - y_range[0]
+        new_x_range = (center_x - x_width / 2, center_x + x_width / 2)
+        new_y_range = (center_y - y_width / 2, center_y + y_width / 2)
+        view_box.setRange(xRange=new_x_range, yRange=new_y_range, padding=0)
 
 
 class TreeWidget(QWidget):
@@ -450,10 +472,9 @@ class TreeWidget(QWidget):
 
         self.tree_widget: TreePlot = TreePlot()
         self.tree_widget.node_clicked.connect(self.selected_nodes.add)
-        self.tree_widget.jump_to_node.connect(
-            lambda node: self.tracks_viewer.tracking_layers.center_view(node)
-        )
+        self.tree_widget.jump_to_node.connect(self.tracks_viewer.center_on_node)
         self.tree_widget.nodes_selected.connect(self.selected_nodes.add_list)
+        self.tracks_viewer.center_node.connect(self.tree_widget.center_on_node)
 
         # Add radiobuttons for switching between different display modes
         self.mode_widget = TreeViewModeWidget()

--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -226,7 +226,7 @@ class CollectionWidget(QWidget):
 
         node = self.tracks_viewer.selected_nodes.next_node(forward)
         if node:
-            self.tracks_viewer.tracking_layers.center_view(node)
+            self.tracks_viewer.center_on_node(node)
 
     def _invert_selection(self) -> None:
         """Invert the current selection"""

--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -94,26 +94,34 @@ class CollectionWidget(QWidget):
 
         # Select widget group
         select_widget = QGroupBox("Selection")
-        selection_layout = QVBoxLayout()
+        selection_layout = QHBoxLayout()
 
-        row1_layout = QHBoxLayout()
+        col1_layout = QVBoxLayout()
         self.select_btn = QPushButton("Select nodes in group")
         self.select_btn.clicked.connect(self._select_nodes)
         self.invert_btn = QPushButton("Invert selection")
         self.invert_btn.clicked.connect(self._invert_selection)
-        row1_layout.addWidget(self.select_btn)
-        row1_layout.addWidget(self.invert_btn)
+        self.jump_to_next_btn = QPushButton("Next selected node")
+        self.jump_to_next_btn.clicked.connect(lambda: self._jump_to_node(forward=True))
+        col1_layout.addWidget(self.select_btn)
+        col1_layout.addWidget(self.invert_btn)
+        col1_layout.addWidget(self.jump_to_next_btn)
 
-        row2_layout = QHBoxLayout()
+        col2_layout = QVBoxLayout()
         self.deselect_btn = QPushButton("Deselect")
         self.deselect_btn.clicked.connect(self.tracks_viewer.selected_nodes.reset)
         self.reselect_btn = QPushButton("Restore selection")
         self.reselect_btn.clicked.connect(self.tracks_viewer.selected_nodes.restore)
-        row2_layout.addWidget(self.deselect_btn)
-        row2_layout.addWidget(self.reselect_btn)
+        self.jump_to_previous_btn = QPushButton("Previous selected node")
+        self.jump_to_previous_btn.clicked.connect(
+            lambda: self._jump_to_node(forward=False)
+        )
+        col2_layout.addWidget(self.deselect_btn)
+        col2_layout.addWidget(self.reselect_btn)
+        col2_layout.addWidget(self.jump_to_previous_btn)
 
-        selection_layout.addLayout(row1_layout)
-        selection_layout.addLayout(row2_layout)
+        selection_layout.addLayout(col1_layout)
+        selection_layout.addLayout(col2_layout)
         select_widget.setLayout(selection_layout)
 
         # edit layout
@@ -201,13 +209,24 @@ class CollectionWidget(QWidget):
 
         if len(self.tracks_viewer.selected_nodes) > 0:
             self.deselect_btn.setEnabled(True)
+            self.jump_to_next_btn.setEnabled(True)
+            self.jump_to_previous_btn.setEnabled(True)
         else:
             self.deselect_btn.setEnabled(False)
+            self.jump_to_next_btn.setEnabled(False)
+            self.jump_to_previous_btn.setEnabled(False)
 
         if self.tracks_viewer.tracks is not None:
             self.new_group_button.setEnabled(True)
         else:
             self.new_group_button.setEnabled(False)
+
+    def _jump_to_node(self, forward: bool) -> None:
+        """Jump to the next/previous selected node in the list"""
+
+        node = self.tracks_viewer.selected_nodes.next_node(forward)
+        if node:
+            self.tracks_viewer.tracking_layers.center_view(node)
 
     def _invert_selection(self) -> None:
         """Invert the current selection"""

--- a/src/motile_tracker/data_views/views_coordinator/node_selection_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/node_selection_list.py
@@ -5,7 +5,8 @@ from qtpy.QtCore import QObject
 
 
 class NodeSelectionList(QObject):
-    """Efficient selection list for nodes with signals on updates."""
+    """Efficient selection list for nodes with signals on updates,
+    with support for iterating through the selection."""
 
     list_updated = Signal()
 
@@ -13,43 +14,47 @@ class NodeSelectionList(QObject):
         super().__init__()
         self._set = set()  # Use a set for O(1) membership
         self._prev_set = set()
+        self._iter_index = 0  # Track position for "next/previous node"
+
+    def _reset_iterator(self):
+        """Reset iteration pointer whenever selection changes."""
+        self._iter_index = 0
 
     def add(self, item, append: bool | None = False):
         """Append or replace an item to the list, depending on the number of items
         present and the keyboard modifiers used. Emit update signal"""
         self._prev_set = self._set.copy()
-
         if item in self._set:
             self._set.remove(item)
         elif append:
             self._set.add(item)
         else:
             self._set = {item}
-
+        self._reset_iterator()
         self.list_updated.emit()
 
     def add_list(self, items: list, append: bool | None = False):
         """Add multiple items to the selection."""
         self._prev_set = self._set.copy()
-
         items_set = set(items)
         if append:
-            # Remove items already present, add the rest
             self._set.symmetric_difference_update(items_set)
         else:
             self._set = items_set
-
+        self._reset_iterator()
         self.list_updated.emit()
 
     def reset(self):
         """Clear all elements in the set"""
         self._prev_set = self._set.copy()
         self._set.clear()
+        self._reset_iterator()
         self.list_updated.emit()
 
     def restore(self):
         """Restore the previous set of nodes"""
         self._set = self._prev_set.copy()
+        self._reset_iterator()
         self.list_updated.emit()
 
     def __contains__(self, item):
@@ -69,3 +74,15 @@ class NodeSelectionList(QObject):
     def as_list(self) -> list:
         """Return the selected nodes as a list (arbitrary order)."""
         return list(self._set)
+
+    def next_node(self, forward=True):
+        """Advance/regress the pointer and return the next/previous node."""
+
+        nodes = self.as_list
+        if not nodes:
+            return None
+        if forward:
+            self._iter_index = (self._iter_index + 1) % len(nodes)
+        else:
+            self._iter_index = (self._iter_index - 1) % len(nodes)
+        return nodes[self._iter_index]

--- a/src/motile_tracker/data_views/views_coordinator/node_selection_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/node_selection_list.py
@@ -16,13 +16,18 @@ class NodeSelectionList(QObject):
         self._prev_set = set()
         self._iter_index = 0  # Track position for "next/previous node"
 
-    def _reset_iterator(self):
+    def _reset_iterator(self) -> None:
         """Reset iteration pointer whenever selection changes."""
         self._iter_index = 0
 
-    def add(self, item, append: bool | None = False):
-        """Append or replace an item to the list, depending on the number of items
-        present and the keyboard modifiers used. Emit update signal"""
+    def add(self, item: int, append: bool = False) -> None:
+        """Append or replace an item in the selection.
+
+        Args:
+            item: The node ID to add or toggle.
+            append: If True, add to existing selection (or remove if already present).
+                If False, replace selection with just this item.
+        """
         self._prev_set = self._set.copy()
         if item in self._set:
             self._set.remove(item)
@@ -33,8 +38,14 @@ class NodeSelectionList(QObject):
         self._reset_iterator()
         self.list_updated.emit()
 
-    def add_list(self, items: list, append: bool | None = False):
-        """Add multiple items to the selection."""
+    def add_list(self, items: list[int], append: bool = False) -> None:
+        """Add multiple items to the selection.
+
+        Args:
+            items: List of node IDs to add.
+            append: If True, toggle items in existing selection.
+                If False, replace selection with these items.
+        """
         self._prev_set = self._set.copy()
         items_set = set(items)
         if append:
@@ -44,41 +55,47 @@ class NodeSelectionList(QObject):
         self._reset_iterator()
         self.list_updated.emit()
 
-    def reset(self):
-        """Clear all elements in the set"""
+    def reset(self) -> None:
+        """Clear all elements from the selection."""
         self._prev_set = self._set.copy()
         self._set.clear()
         self._reset_iterator()
         self.list_updated.emit()
 
-    def restore(self):
-        """Restore the previous set of nodes"""
+    def restore(self) -> None:
+        """Restore the previous selection."""
         self._set = self._prev_set.copy()
         self._reset_iterator()
         self.list_updated.emit()
 
-    def __contains__(self, item):
+    def __contains__(self, item: int) -> bool:
         return item in self._set
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self._set)
 
     def __iter__(self):
         return iter(self._set)
 
-    def __getitem__(self, index):
-        """Convert to list on demand for indexing"""
+    def __getitem__(self, index: int) -> int:
+        """Convert to list on demand for indexing."""
         return list(self._set)[index]
 
     @property
-    def as_list(self) -> list:
+    def as_list(self) -> list[int]:
         """Return the selected nodes as a list (arbitrary order)."""
         return list(self._set)
 
-    def next_node(self, forward=True):
-        """Advance/regress the pointer and return the next/previous node."""
+    def next_node(self, forward: bool = True) -> int | None:
+        """Advance/regress the pointer and return the next/previous node.
 
-        nodes = self.as_list
+        Args:
+            forward: If True, move to next node; if False, move to previous.
+
+        Returns:
+            The node ID, or None if selection is empty.
+        """
+        nodes = sorted(self._set)
         if not nodes:
             return None
         if forward:

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -29,6 +29,8 @@ from motile_tracker.data_views.views_coordinator.user_dialogs import (
     confirm_force_operation,
 )
 
+BASE_TEXT = "Click: select node\nShift+Click: append to selection\nCtrl+Click: center node\n[Q]: toggle display\nCurrent display mode: "
+
 
 class TracksViewer:
     """Purposes of the TracksViewer:
@@ -187,18 +189,18 @@ class TracksViewer:
     def set_display_mode(self, mode: str) -> None:
         """Update the display mode and call to update colormaps for points, labels, and tracks"""
 
-        # toggle between 'all' and 'lineage'
         if mode == "lineage":
             self.mode = "lineage"
-            self.viewer.text_overlay.text = "Toggle Display [Q]\n Lineage"
+            self.viewer.text_overlay.text = BASE_TEXT + "Lineage"
         elif mode == "group":
             self.mode = "group"
-            self.viewer.text_overlay.text = "Toggle Display [Q]\n Group"
+            self.viewer.text_overlay.text = BASE_TEXT + "Group"
         else:
             self.mode = "all"
-            self.viewer.text_overlay.text = "Toggle Display [Q]\n All"
+            self.viewer.text_overlay.text = BASE_TEXT + "All"
 
         self.viewer.text_overlay.visible = True
+        self.viewer.text_overlay.font_size = 8
         self.filter_visible_nodes()
         self.tracking_layers.update_visible(self.visible)
 
@@ -241,7 +243,9 @@ class TracksViewer:
     def update_selection(self) -> None:
         """Sets the view and triggers visualization updates in other components"""
 
-        self.set_napari_view()
+        if len(self.selected_nodes) == 1:
+            self.tracking_layers.center_view(self.selected_nodes[0])
+
         self.filter_visible_nodes()
         self.tracking_layers.update_visible(self.visible)
 
@@ -252,14 +256,6 @@ class TracksViewer:
 
         self.set_track_id_color(self.selected_track)
         self.update_track_id.emit()
-
-    def set_napari_view(self) -> None:
-        """Adjust the current_step of the viewer to jump to the last item of the
-        selected_nodes list
-        """
-        if len(self.selected_nodes) > 0:
-            node = self.selected_nodes[-1]
-            self.tracking_layers.center_view(node)
 
     def delete_node(self, event=None):
         """Calls the tracks controller to delete currently selected nodes"""

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -261,7 +261,7 @@ class TracksViewer:
     def update_selection(self, set_view: bool = True) -> None:
         """Sets the view and triggers visualization updates in other components"""
 
-        if set_view and len(self.selected_nodes) > 0:
+        if set_view and len(self.selected_nodes) == 1:
             self.center_on_node(self.selected_nodes[0])
 
         self.filter_visible_nodes()

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -29,7 +29,7 @@ from motile_tracker.data_views.views_coordinator.user_dialogs import (
     confirm_force_operation,
 )
 
-BASE_TEXT = "Click: select node\nShift+Click: append to selection\nCtrl+Click: center node\n[Q]: toggle display\nCurrent display mode: "
+BASE_TEXT = "Click: select node\nShift+Click: append to selection\nCtrl/Cmd+Click: center node\n[Q]: toggle display\nCurrent display mode: "
 
 
 class TracksViewer:

--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -168,17 +168,14 @@ class MotileWidget(QWidget):
         self.new_run(run, run.run_name)
 
     def _title_widget(self) -> QWidget:
-        """Create the title and intro paragraph widget, with links to docs
+        """Create the intro paragraph widget, with links to motile docs.
 
         Returns:
-            QWidget: A widget introducing the motile tracker and linking to docs
+            QWidget: A widget describing the tracking tab and linking to motile docs
         """
-        richtext = r"""<h3>Tracking with Motile</h3>
-        <p>This tracker uses the
+        richtext = r"""<p>This tab uses the
         <a href="https://funkelab.github.io/motile/"><font color=yellow>motile</font></a> library to
-        track objects with global optimization. See the
-        <a href="https://funkelab.github.io/motile_tracker/"><font color=yellow>user guide</font></a>
-        for a tutorial to the tracker functionality."""  # noqa
+        track objects with global optimization.</p>"""
         label = QLabel(richtext)
         label.setWordWrap(True)
         label.setOpenExternalLinks(True)

--- a/src/motile_tracker/napari.yaml
+++ b/src/motile_tracker/napari.yaml
@@ -1,5 +1,5 @@
 name: motile-tracker
-display_name: Motile
+display_name: Motile Tracker
 # use 'hidden' to remove plugin from napari hub search results
 visibility: public
 # see https://napari.org/stable/plugins/manifest.html for valid categories
@@ -29,11 +29,11 @@ contributions:
       title: "Load Mouse Embryo_Membrane tracking dataset"
   widgets:
     - command: motile-tracker.main_app
-      display_name: Motile Main Widget
+      display_name: All
     - command: motile-tracker.menus_widget
-      display_name: Motile Menus Widget
+      display_name: Menus
     - command: motile-tracker.tree_widget
-      display_name: Motile Lineage View
+      display_name: Lineage View
   sample_data:
     - command: motile-tracker.Fluo_N2DL_HeLa
       key: "Fluo-N2DL-HeLa"


### PR DESCRIPTION
Changes: 
- single click: center and select node
- Shift+click: append to selection. If more than one node is selected, do not center the view
- Ctrl (/CMD) + click: center the viewer to the clicked node (do not add to selection). 
- In the groups tab: buttons to jump to next/previous selected node. 

To discuss: 
- The node selection list was previously updated to be a set and not a list. So the cycle order does not necessarily match with the order that the nodes were added. Do we want to switch back to a list? 
- I put the click controls explanation in the viewer.text_overlay for now, but I think it might be too much clutter. Do we want to display this somewhere else? 