### PR TITLE
bugfix: update the groups before resetting the node selection list

### DIFF
--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -117,6 +117,8 @@ class TracksViewer:
         updated. Restore the selected_nodes, if possible
         """
 
+        self.collection_widget._refresh()
+
         if len(self.selected_nodes) > 0 and any(
             not self.tracks.graph.has_node(node) for node in self.selected_nodes
         ):
@@ -125,7 +127,6 @@ class TracksViewer:
         self.tracking_layers._refresh()
 
         self.tracks_updated.emit(refresh_view)
-        self.collection_widget._refresh()
 
         # if a new node was added, we would like to select this one now (call this after
         # emitting the signal, because if the node is a new node, we have to update the


### PR DESCRIPTION
When you are in group mode, and you delete a node that belongs to the current group, an error is triggered because the deleted node is in the list of visible nodes. Fixed by refreshing the groups before resetting the selection list, which the triggers visualization update.