### PR TITLE
Suppress floating import widgets when updating dialog

### DIFF
--- a/src/motile_tracker/import_export/menus/import_dialog.py
+++ b/src/motile_tracker/import_export/menus/import_dialog.py
@@ -120,7 +120,6 @@ class ImportDialog(QDialog):
         self.seg = (
             self.segmentation_widget.include_seg() if checked is None else not checked
         )
-        self.scale_widget.setVisible(self.seg)
 
         if self.import_type == "csv":
             self.incl_z = self.dimension_widget.incl_z
@@ -161,6 +160,8 @@ class ImportDialog(QDialog):
             self.prop_map_widget.mapping_labels["seg_id"].setVisible(self.seg)
 
         self._update_finish_button()
+        self.scale_widget.setVisible(self.seg)
+
         self._resize_dialog()
 
     def infer_dims_from_segmentation(self) -> None:
@@ -198,10 +199,9 @@ class ImportDialog(QDialog):
     def _update_segmentation_widget(self) -> None:
         """Refresh the geff segmentation widget based on the geff root group."""
 
+        self.segmentation_widget.setVisible(False)
         if self.import_widget.root is not None:
             self.segmentation_widget.update_root(self.import_widget.root)
-        else:
-            self.segmentation_widget.setVisible(False)
         self._update_finish_button()
         self._resize_dialog()
 

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -163,7 +163,7 @@ class StandardFieldMapWidget(QWidget):
         self.seg = seg
         self.incl_z = incl_z
 
-        self.setVisible(True)
+        self.setVisible(False)
         self.node_attrs = list(root["nodes"]["props"].group_keys())
         self.metadata = dict(root.attrs.get("geff", {}))
 
@@ -192,6 +192,7 @@ class StandardFieldMapWidget(QWidget):
                 self.standard_fields.insert(1, "z")
 
         self.update_mapping(seg)
+        self.setVisible(True)
 
     def _update_props_left(self) -> None:
         """Update the list of columns that have not been mapped yet"""
@@ -412,6 +413,7 @@ class StandardFieldMapWidget(QWidget):
             seg (bool = False): whether a segmentation is associated with this data
         """
 
+        self.setVisible(False)
         self.mapping_labels = {}
         self.mapping_widgets = {}
         clear_layout(self.mapping_layout)  # clear layout first
@@ -458,6 +460,8 @@ class StandardFieldMapWidget(QWidget):
         self.optional_mapping_layout.addWidget(header_assign, 0, 1)
         self.optional_mapping_layout.addWidget(header_recompute, 0, 2)
         self._update_props_left()
+
+        self.setVisible(True)
         self.setMinimumHeight(350)
 
     def get_name_map(self) -> dict[str, str]:

--- a/src/motile_tracker/import_export/menus/scale_widget.py
+++ b/src/motile_tracker/import_export/menus/scale_widget.py
@@ -61,7 +61,6 @@ class ScaleWidget(QWidget):
             ndim = 4 if incl_z else 3
             self.scale = list([1.0] * ndim)
 
-        self.setVisible(True)
         clear_layout(self.scale_layout)
         self.scale_form_layout = QFormLayout()
 
@@ -78,6 +77,7 @@ class ScaleWidget(QWidget):
         self.scale_form_layout.addRow(QLabel("x"), self.x_spin_box)
 
         self.scale_layout.addLayout(self.scale_form_layout)
+        self.setVisible(True)
 
     def _scale_spin_box(self, value: float) -> QDoubleSpinBox:
         """Return a QDoubleSpinBox for scaling values"""

--- a/src/motile_tracker/import_export/menus/segmentation_widgets.py
+++ b/src/motile_tracker/import_export/menus/segmentation_widgets.py
@@ -331,11 +331,11 @@ class GeffSegmentationWidget(QWidget):
         Args:
             root (zarr.Group | None): The root group of the geff zarr store.
         """
+        self.setVisible(False)
         self.root = root
         clear_layout(self.related_objects_layout)
         self.related_object_radio_buttons = {}
         if self.root is not None:
-            self.setVisible(True)
             metadata = dict(self.root.attrs)
             related_objects = metadata.get("geff", {}).get("related_objects", None)
             if related_objects:
@@ -346,8 +346,7 @@ class GeffSegmentationWidget(QWidget):
                         self.button_group.addButton(radio)
                         self.related_object_radio_buttons[obj.get("path", None)] = radio
                         self.related_objects_layout.addWidget(radio)
-        else:
-            self.setVisible(False)
+            self.setVisible(True)
 
     def _toggle_segmentation(self, checked: bool) -> None:
         """Toggle visibility of the segmentation widget based on the radio button


### PR DESCRIPTION
(Especially) on Windows, when clicking through the import dialog, some widgets appear to be floating/detached for about a second, which looks buggy. To suppress this 'glitching', hide the widgets while they are updating .