### PR TITLE
Reconstruct the colormap instead of deepcopying it when sharing colormap with orthoviews

### DIFF
--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -1,9 +1,9 @@
-import copy
 import inspect
 
 import napari_orthogonal_views.ortho_view_widget as ov_widget
 from napari import Viewer
 from napari.layers import Labels, Layer, Points, Shapes
+from napari.utils.colormaps import DirectLabelColormap
 from napari.utils.events import Event
 from napari.utils.notifications import show_info
 from napari_orthogonal_views.ortho_view_manager import (  # noqa
@@ -238,7 +238,9 @@ def colormap_hook(orig_layer: TrackLabels, copied_layer: Labels) -> None:
         ContourLabels instance. Check the slice ndisplay and contour settings to adjust
         background opacity accordingly."""
 
-        copied_layer.colormap = copy.deepcopy(orig_layer.colormap)
+        copied_layer.colormap = DirectLabelColormap(
+            color_dict=orig_layer.colormap.color_dict
+        )
         if copied_layer._slice.slice_input.ndisplay == 3 and orig_layer.contour > 0:
             copied_layer.set_opacity(orig_layer.background, 0)
         else:


### PR DESCRIPTION
@AnniekStok 