### PR TITLE
Fix missing static and group features export

### DIFF
--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -492,7 +492,7 @@ class StandardFieldMapWidget(QWidget):
         - Column name (to load from that column)
         - "Recompute" (to compute from segmentation)
 
-        Custom and Group features are excluded (handled via name_map).
+        Custom and Group features are handled by adding themselves under their own name.
         """
         features = {}
         for attr, widgets in self.optional_features.items():
@@ -501,8 +501,7 @@ class StandardFieldMapWidget(QWidget):
                 recompute = widgets["recompute"].isChecked()
 
                 if selected in ("Custom", "Group"):
-                    # Custom/Group features are added to name_map instead
-                    continue
+                    features[attr] = attr  # just add itself with its own name
                 elif recompute:
                     features[selected] = "Recompute"
                 else:
@@ -514,7 +513,7 @@ class StandardFieldMapWidget(QWidget):
 
         Returns dict mapping property name to recompute boolean.
 
-        Custom and Group features are excluded (handled via name_map).
+        Custom and Group features are handled by adding themselves under their own name.
         """
         node_features = {}
         for attr, widgets in self.optional_features.items():
@@ -523,8 +522,7 @@ class StandardFieldMapWidget(QWidget):
                 recompute = widgets["recompute"].isChecked()
 
                 if selected in ("Custom", "Group"):
-                    # Custom/Group features are added to name_map instead
-                    continue
+                    node_features[attr] = attr  # just add itself with its own name
 
                 node_features[attr] = recompute
         return node_features

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -493,6 +493,7 @@ class StandardFieldMapWidget(QWidget):
         - "Recompute" (to compute from segmentation)
 
         Custom and Group features are handled by adding themselves under their own name.
+        If the name is the same as an annotated feature, unexpected behavior will occur.
         """
         features = {}
         for attr, widgets in self.optional_features.items():


### PR DESCRIPTION
Return static and group features via prop_map_widget.get_features to ensure they can be exported to geff or csv by funtracks.

https://github.com/funkelab/funtracks/pull/186