### PR TITLE
Add type string tracks to TrackGraph

### DIFF
--- a/src/motile_tracker/data_views/views/layers/track_graph.py
+++ b/src/motile_tracker/data_views/views/layers/track_graph.py
@@ -92,6 +92,8 @@ class TrackGraph(napari.layers.Tracks):
     """Extended tracks layer that holds the track information and emits and responds
     to dynamics visualization signals"""
 
+    _type_string = "tracks"
+
     def __init__(
         self,
         name: str,


### PR DESCRIPTION
Fixed a specific problem I was having when the orthoviews were trying to make a copy of the TrackGraph layer using the layer_dict and interpreting the 2D array of data as an Image layer. Also matches what the other TrackLabels and TrackPoints layers do