### PR TITLE
Update tests to match v2 assumptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 dependencies =[
     "napari>=0.6.2,<0.7.0",
     #TODO: make this a proper PyPI release
-    "funtracks>=2.0.0-a3,<3",
+    "funtracks>=2.0.0-a6,<3",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/src/motile_tracker/data_views/views_coordinator/groups.py
+++ b/src/motile_tracker/data_views/views_coordinator/groups.py
@@ -235,8 +235,7 @@ class CollectionWidget(QWidget):
             )  # update the count, but keep deleted nodes in the collection.
 
     def retrieve_existing_groups(self) -> None:
-        """Create collections based on the node attributes. Nodes assigned to a group
-        should have that group in their 'group' attribute"""
+        """Create collections based on the node attributes"""
 
         # first clear the entire list
         self.collection_list.clear()
@@ -246,7 +245,7 @@ class CollectionWidget(QWidget):
         group_features = [
             (group_name, group_dict)
             for group_name, group_dict in self.tracks_viewer.tracks.features.items()
-            if group_dict["value_type"] == "bool"
+            if group_dict["value_type"] == "bool" and group_name != "solution"
         ]
         group_dict = {}
         for group_name, _ in group_features:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,7 +108,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 1681.0,
             "track_id": 1,
             "lineage_id": 1,
-            "solution": 1,
+            "solution": True,
         },
         {
             "t": 1,
@@ -116,7 +116,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 441.0,
             "track_id": 2,
             "lineage_id": 1,
-            "solution": 1,
+            "solution": True,
         },
         {
             "t": 1,
@@ -124,7 +124,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 961.0,
             "track_id": 3,
             "lineage_id": 1,
-            "solution": 1,
+            "solution": True,
         },
         {
             "t": 2,
@@ -132,7 +132,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 16.0,
             "track_id": 3,
             "lineage_id": 1,
-            "solution": 1,
+            "solution": True,
         },
         {
             "t": 4,
@@ -140,7 +140,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 16.0,
             "track_id": 3,
             "lineage_id": 1,
-            "solution": 1,
+            "solution": True,
         },
         {
             "t": 4,
@@ -148,7 +148,7 @@ def graph_2d() -> td.graph.GraphView:
             "area": 16.0,
             "track_id": 5,
             "lineage_id": 2,
-            "solution": 1,
+            "solution": True,
         },
     ]
     for node, bbox in zip(nodes, bboxes, strict=True):
@@ -157,10 +157,10 @@ def graph_2d() -> td.graph.GraphView:
     graph.bulk_add_nodes(nodes=nodes, indices=[1, 2, 3, 4, 5, 6])
     graph.bulk_add_edges(
         [
-            {"source_id": 1, "target_id": 2, "iou": 0.0, "solution": 1},
-            {"source_id": 1, "target_id": 3, "iou": 0.395, "solution": 1},
-            {"source_id": 3, "target_id": 4, "iou": 0.0, "solution": 1},
-            {"source_id": 4, "target_id": 5, "iou": 1.0, "solution": 1},
+            {"source_id": 1, "target_id": 2, "iou": 0.0, "solution": True},
+            {"source_id": 1, "target_id": 3, "iou": 0.395, "solution": True},
+            {"source_id": 3, "target_id": 4, "iou": 0.0, "solution": True},
+            {"source_id": 4, "target_id": 5, "iou": 1.0, "solution": True},
         ]
     )
     graph._update_metadata(segmentation_shape=(5, 100, 100))
@@ -184,9 +184,9 @@ def graph_3d() -> td.graph.GraphView:
         [45, 35, 30, 76, 66, 61],  # node 3, t=1: sphere center=(60,50,45) r=15
     ]
     nodes = [
-        {"t": 0, "pos": [50.0, 50.0, 50.0], "solution": 1},
-        {"t": 1, "pos": [20.0, 50.0, 80.0], "solution": 1},
-        {"t": 1, "pos": [60.0, 50.0, 45.0], "solution": 1},
+        {"t": 0, "pos": [50.0, 50.0, 50.0], "solution": True},
+        {"t": 1, "pos": [20.0, 50.0, 80.0], "solution": True},
+        {"t": 1, "pos": [60.0, 50.0, 45.0], "solution": True},
     ]
     for node, bbox in zip(nodes, bboxes, strict=True):
         node[td.DEFAULT_ATTR_KEYS.MASK] = _make_mask(bbox)
@@ -194,8 +194,8 @@ def graph_3d() -> td.graph.GraphView:
     graph.bulk_add_nodes(nodes=nodes, indices=[1, 2, 3])
     graph.bulk_add_edges(
         [
-            {"source_id": 1, "target_id": 2, "solution": 1},
-            {"source_id": 1, "target_id": 3, "solution": 1},
+            {"source_id": 1, "target_id": 2, "solution": True},
+            {"source_id": 1, "target_id": 3, "solution": True},
         ]
     )
     graph._update_metadata(segmentation_shape=(2, 100, 100, 100))
@@ -241,7 +241,7 @@ def graph_3d_with_division() -> td.graph.GraphView:
                 "area": 1000.0,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bboxes[0]),
                 td.DEFAULT_ATTR_KEYS.BBOX: np.array(bboxes[0], dtype=np.int64),
-                "solution": 1,
+                "solution": True,
             },
             {
                 "t": 1,
@@ -249,7 +249,7 @@ def graph_3d_with_division() -> td.graph.GraphView:
                 "area": 1000.0,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bboxes[1]),
                 td.DEFAULT_ATTR_KEYS.BBOX: np.array(bboxes[1], dtype=np.int64),
-                "solution": 1,
+                "solution": True,
             },
             {
                 "t": 2,
@@ -257,7 +257,7 @@ def graph_3d_with_division() -> td.graph.GraphView:
                 "area": 1000.0,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bboxes[2]),
                 td.DEFAULT_ATTR_KEYS.BBOX: np.array(bboxes[2], dtype=np.int64),
-                "solution": 1,
+                "solution": True,
             },
             {
                 "t": 2,
@@ -265,16 +265,16 @@ def graph_3d_with_division() -> td.graph.GraphView:
                 "area": 1000.0,
                 td.DEFAULT_ATTR_KEYS.MASK: _make_mask(bboxes[3]),
                 td.DEFAULT_ATTR_KEYS.BBOX: np.array(bboxes[3], dtype=np.int64),
-                "solution": 1,
+                "solution": True,
             },
         ],
         indices=[1, 2, 3, 4],
     )
     graph.bulk_add_edges(
         [
-            {"source_id": 1, "target_id": 2, "solution": 1},
-            {"source_id": 2, "target_id": 3, "solution": 1},
-            {"source_id": 2, "target_id": 4, "solution": 1},
+            {"source_id": 1, "target_id": 2, "solution": True},
+            {"source_id": 2, "target_id": 3, "solution": True},
+            {"source_id": 2, "target_id": 4, "solution": True},
         ]
     )
     graph._update_metadata(segmentation_shape=(5, 100, 100, 100))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -203,6 +203,15 @@ def graph_3d() -> td.graph.GraphView:
 
 
 @pytest.fixture
+def graph_3d_without_segmentation(graph_3d: td.graph.GraphView) -> td.graph.GraphView:
+    """Return a copy of graph_3d without segmentation-related node attributes."""
+    graph_without_seg = graph_3d.detach().filter().subgraph()
+    graph_without_seg.remove_node_attr_key(td.DEFAULT_ATTR_KEYS.MASK)
+    graph_without_seg.remove_node_attr_key(td.DEFAULT_ATTR_KEYS.BBOX)
+    return graph_without_seg
+
+
+@pytest.fixture
 def graph_2d_without_segmentation(graph_2d: td.graph.GraphView) -> td.graph.GraphView:
     """Return a copy of graph_2d without segmentation-related node attributes."""
     graph_without_seg = graph_2d.detach().filter().subgraph()

--- a/tests/data_views/test_center_view.py
+++ b/tests/data_views/test_center_view.py
@@ -39,7 +39,7 @@ def _make_single_node_graph(
         database=str(tmp_path / "graph.db"),
     )
 
-    node: dict = {"t": 0, "pos": list(pos), "area": 1000.0, "solution": 1}
+    node: dict = {"t": 0, "pos": list(pos), "area": 1000.0, "solution": True}
     if seg_bbox is not None:
         bbox = np.array(seg_bbox, dtype=np.int64)
         mask_shape = tuple(int(bbox[i + 3] - bbox[i]) for i in range(3))

--- a/tests/data_views/test_track_points.py
+++ b/tests/data_views/test_track_points.py
@@ -182,7 +182,7 @@ def test_create_node_attrs(viewer, solution_tracks_2d):
     # Verify attributes
     assert "pos" in attrs
     assert "t" in attrs
-    assert "track_id" in attrs
+    assert "tracklet_id" in attrs
     assert attrs["t"] == 1
     assert np.array_equal(attrs["pos"], [50, 50])
     # Test 2: Activates new track_id if none selected

--- a/tests/data_views/views/tree_view/test_tree_widget_utils.py
+++ b/tests/data_views/views/tree_view/test_tree_widget_utils.py
@@ -53,7 +53,7 @@ def test_get_features_from_tracks_individual_pos_attrs():
         ndim=3,
     )
     graph.bulk_add_nodes(
-        nodes=[{"t": 0, "y": 10.0, "x": 20.0, "solution": 1}],
+        nodes=[{"t": 0, "y": 10.0, "x": 20.0, "solution": True}],
         indices=[1],
     )
     tracks = SolutionTracks(graph=graph, ndim=3, time_attr="t", pos_attr=["y", "x"])
@@ -80,19 +80,25 @@ def test_extract_sorted_tracks_incomplete_lineage():
     )
     graph.bulk_add_nodes(
         nodes=[
-            {"t": 0, "pos": [0.0, 0.0], "track_id": 1, "solution": 1},  # A, node 1
-            {"t": 1, "pos": [0.0, 0.0], "track_id": 1, "solution": 1},  # B, node 2
-            {"t": 2, "pos": [0.0, 0.0], "track_id": 2, "solution": 1},  # C, node 3
+            {"t": 0, "pos": [0.0, 0.0], "track_id": 1, "solution": True},  # A, node 1
+            {"t": 1, "pos": [0.0, 0.0], "track_id": 1, "solution": True},  # B, node 2
+            {"t": 2, "pos": [0.0, 0.0], "track_id": 2, "solution": True},  # C, node 3
         ],
         indices=[1, 2, 3],
     )
     graph.bulk_add_edges(
         [
-            {"source_id": 1, "target_id": 2, "solution": 1},  # A -> B
-            {"source_id": 2, "target_id": 3, "solution": 1},  # B -> C (cross boundary)
+            {"source_id": 1, "target_id": 2, "solution": True},  # A -> B
+            {
+                "source_id": 2,
+                "target_id": 3,
+                "solution": True,
+            },  # B -> C (cross boundary)
         ]
     )
-    tracks = SolutionTracks(graph=graph, ndim=3, time_attr="t")
+    tracks = SolutionTracks(
+        graph=graph, ndim=3, time_attr="t", tracklet_attr="track_id"
+    )
 
     colormap = napari.utils.colormaps.label_colormap(49, seed=0.5, background_value=0)
     track_df, _ = extract_sorted_tracks(tracks, colormap)

--- a/tests/data_views/views_coordinator/test_tracks_viewer.py
+++ b/tests/data_views/views_coordinator/test_tracks_viewer.py
@@ -118,13 +118,13 @@ class TestEdgeOperations:
                     "area": 100.0,
                     "track_id": 5,
                     "lineage_id": 2,
-                    "solution": 1,
+                    "solution": True,
                 }
             ],
             indices=[7],
         )
         graph_2d_without_segmentation.bulk_add_edges(
-            [{"source_id": 7, "target_id": 6, "solution": 1}]
+            [{"source_id": 7, "target_id": 6, "solution": True}]
         )
 
         tracks = SolutionTracks(

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -393,7 +393,9 @@ def test_csv_import_without_segmentation(
     assert dialog.tracks.ndim == 3
 
 
-def test_geff_import_2d_with_segmentation(qtbot, tmp_path, graph_2d, monkeypatch):
+def test_geff_import_2d_with_segmentation(
+    qtbot, tmp_path, graph_2d_without_segmentation, segmentation_2d, monkeypatch
+):
     """Test exporting and re-importing 2D tracks with segmentation.
     This tests whether the full workflow works end-to-end.
     """
@@ -401,10 +403,11 @@ def test_geff_import_2d_with_segmentation(qtbot, tmp_path, graph_2d, monkeypatch
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
     # Create tracks and export to GEFF (as motile_tracker does in tracks_list.py:237)
-    tracks = Tracks(graph_2d, ndim=3, time_attr="t")
+    tracks = Tracks(
+        graph_2d_without_segmentation, ndim=3, time_attr="t", tracklet_attr="track_id"
+    )
     geff_path = tmp_path / "test_tracks.zarr"
     export_to_geff(tracks, geff_path)
-
     # Create import dialog and load the GEFF file
     dialog = ImportDialog(import_type="geff")
     qtbot.addWidget(dialog)
@@ -418,7 +421,7 @@ def test_geff_import_2d_with_segmentation(qtbot, tmp_path, graph_2d, monkeypatch
     # Select "Use external segmentation" option and set path
     dialog.segmentation_widget.external_segmentation_radio.setChecked(True)
     seg_path = tmp_path / "segmentation.zarr"
-    zarr.save_array(seg_path, np.asarray(tracks.segmentation))
+    zarr.save_array(seg_path, segmentation_2d)
     dialog.segmentation_widget.segmentation_widget.image_path_line.setText(
         str(seg_path)
     )
@@ -441,8 +444,8 @@ def test_geff_import_2d_with_segmentation(qtbot, tmp_path, graph_2d, monkeypatch
     # Verify tracks were imported successfully
     assert hasattr(dialog, "tracks"), "Dialog should have tracks attribute after import"
     assert dialog.tracks is not None, "Tracks should not be None"
-    assert dialog.tracks.graph.num_nodes() == graph_2d.num_nodes()
-    assert dialog.tracks.graph.num_edges() == graph_2d.num_edges()
+    assert dialog.tracks.graph.num_nodes() == graph_2d_without_segmentation.num_nodes()
+    assert dialog.tracks.graph.num_edges() == graph_2d_without_segmentation.num_edges()
     assert dialog.tracks.ndim == 3
     for node_id in dialog.tracks.graph.node_ids():
         dialog.tracks.get_time(node_id)
@@ -600,7 +603,9 @@ def test_geff_import_without_segmentation(
         dialog.tracks.get_time(node_id)
 
 
-def test_geff_import_without_axes_metadata(qtbot, tmp_path, graph_2d, monkeypatch):
+def test_geff_import_without_axes_metadata(
+    qtbot, tmp_path, graph_2d_without_segmentation, segmentation_2d, monkeypatch
+):
     """Test importing a geff that has no axes metadata.
     This tests the automatic axes generation when metadata is missing.
     """
@@ -608,7 +613,9 @@ def test_geff_import_without_axes_metadata(qtbot, tmp_path, graph_2d, monkeypatc
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
     # Create tracks and export to GEFF (this creates valid axes metadata)
-    tracks = Tracks(graph_2d, ndim=3, time_attr="t")
+    tracks = Tracks(
+        graph_2d_without_segmentation, ndim=3, time_attr="t", tracklet_attr="track_id"
+    )
     geff_path = tmp_path / "test_tracks_no_axes.zarr"
     export_to_geff(tracks, geff_path)
 
@@ -635,7 +642,7 @@ def test_geff_import_without_axes_metadata(qtbot, tmp_path, graph_2d, monkeypatc
     # Select "Use external segmentation" option and set path
     dialog.segmentation_widget.external_segmentation_radio.setChecked(True)
     seg_path = tmp_path / "segmentation.zarr"
-    zarr.save_array(seg_path, np.asarray(tracks.segmentation))
+    zarr.save_array(seg_path, segmentation_2d)
     dialog.segmentation_widget.segmentation_widget.image_path_line.setText(
         str(seg_path)
     )
@@ -656,8 +663,8 @@ def test_geff_import_without_axes_metadata(qtbot, tmp_path, graph_2d, monkeypatc
     # Verify tracks were imported successfully
     assert hasattr(dialog, "tracks"), "Dialog should have tracks attribute after import"
     assert dialog.tracks is not None, "Tracks should not be None"
-    assert dialog.tracks.graph.num_nodes() == graph_2d.num_nodes()
-    assert dialog.tracks.graph.num_edges() == graph_2d.num_edges()
+    assert dialog.tracks.graph.num_nodes() == graph_2d_without_segmentation.num_nodes()
+    assert dialog.tracks.graph.num_edges() == graph_2d_without_segmentation.num_edges()
     assert dialog.tracks.ndim == 3
 
     # Verify axes metadata was generated
@@ -774,7 +781,7 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
     geff_path = tmp_path / "old_geff_with_related.zarr"
     # save_segmentation=True writes segmentation + adds related_objects to geff metadata.
     # seg_label_attr=None preserves node IDs as pixel values (consistent with other tests).
-    export_to_geff(tracks, geff_path, save_segmentation=True, seg_label_attr=None)
+    export_to_geff(tracks, geff_path, save_segmentation=True, seg_relabel=None)
 
     # Remove segmentation_shape to simulate old funtracks export
     root = zarr.open_group(geff_path / "tracks.geff", mode="r+")

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -393,21 +393,30 @@ def test_csv_import_without_segmentation(
     assert dialog.tracks.ndim == 3
 
 
-def test_geff_import_2d_with_segmentation(
-    qtbot, tmp_path, graph_2d_without_segmentation, segmentation_2d, monkeypatch
+@pytest.mark.parametrize(
+    "graph_fixture, seg_fixture, ndim",
+    [
+        ("graph_2d_without_segmentation", "segmentation_2d", 3),
+        ("graph_3d_without_segmentation", "segmentation_3d", 4),
+    ],
+)
+def test_geff_import_with_segmentation(
+    qtbot, tmp_path, graph_fixture, seg_fixture, ndim, monkeypatch, request
 ):
-    """Test exporting and re-importing 2D tracks with segmentation.
-    This tests whether the full workflow works end-to-end.
+    """Test exporting and re-importing tracks with external segmentation.
+    This tests whether the full workflow works end-to-end for 2D and 3D.
     """
+    graph = request.getfixturevalue(graph_fixture)
+    segmentation = request.getfixturevalue(seg_fixture)
+
     # Mock _resize_dialog to avoid screen access in headless CI
     monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
 
     # Create tracks and export to GEFF (as motile_tracker does in tracks_list.py:237)
-    tracks = Tracks(
-        graph_2d_without_segmentation, ndim=3, time_attr="t", tracklet_attr="track_id"
-    )
+    tracks = Tracks(graph, ndim=ndim, time_attr="t", tracklet_attr="track_id")
     geff_path = tmp_path / "test_tracks.zarr"
     export_to_geff(tracks, geff_path)
+
     # Create import dialog and load the GEFF file
     dialog = ImportDialog(import_type="geff")
     qtbot.addWidget(dialog)
@@ -421,67 +430,7 @@ def test_geff_import_2d_with_segmentation(
     # Select "Use external segmentation" option and set path
     dialog.segmentation_widget.external_segmentation_radio.setChecked(True)
     seg_path = tmp_path / "segmentation.zarr"
-    zarr.save_array(seg_path, segmentation_2d)
-    dialog.segmentation_widget.segmentation_widget.image_path_line.setText(
-        str(seg_path)
-    )
-    dialog.segmentation_widget.segmentation_widget.seg_path_updated.emit()
-
-    # Verify finish button is enabled
-    assert dialog.finish_button.isEnabled() is True, (
-        "Finish button should be enabled with valid GEFF and segmentation"
-    )
-
-    # Set seg_id mapping to "None" since node id == seg_id (automapping is incorrect)
-    prop_map = dialog.prop_map_widget
-    seg_combo = prop_map.mapping_widgets["seg_id"]
-    seg_combo.setCurrentText("None")
-    prop_map._update_props_left()
-
-    # Import the tracks
-    dialog._finish()
-
-    # Verify tracks were imported successfully
-    assert hasattr(dialog, "tracks"), "Dialog should have tracks attribute after import"
-    assert dialog.tracks is not None, "Tracks should not be None"
-    assert dialog.tracks.graph.num_nodes() == graph_2d_without_segmentation.num_nodes()
-    assert dialog.tracks.graph.num_edges() == graph_2d_without_segmentation.num_edges()
-    assert dialog.tracks.ndim == 3
-    for node_id in dialog.tracks.graph.node_ids():
-        dialog.tracks.get_time(node_id)
-
-    # Area should be enabled and computed when segmentation is present
-    assert "area" in dialog.tracks.features
-    for node_id in dialog.tracks.graph.node_ids():
-        assert dialog.tracks.graph.nodes[node_id]["area"] > 0
-
-
-def test_geff_import_3d_with_segmentation(
-    qtbot, tmp_path, solution_tracks_3d, monkeypatch
-):
-    """Test exporting and re-importing 3D tracks with segmentation."""
-    # Mock _resize_dialog to avoid screen access in headless CI
-    monkeypatch.setattr(ImportDialog, "_resize_dialog", lambda self: None)
-
-    # Create tracks and export to GEFF
-    tracks = solution_tracks_3d
-    geff_path = tmp_path / "test_tracks_3d.zarr"
-    export_to_geff(tracks, geff_path)
-
-    # Create import dialog and load the GEFF file
-    dialog = ImportDialog(import_type="geff")
-    qtbot.addWidget(dialog)
-
-    # Load the geff file
-    dialog.import_widget._load_geff(geff_path)
-
-    # Verify geff root was loaded
-    assert dialog.import_widget.root is not None, "Failed to load GEFF root"
-
-    # Select "Use external segmentation" option and set path
-    dialog.segmentation_widget.external_segmentation_radio.setChecked(True)
-    seg_path = tmp_path / "segmentation_3d.zarr"
-    zarr.save_array(seg_path, np.asarray(tracks.segmentation))
+    zarr.save_array(seg_path, segmentation)
     dialog.segmentation_widget.segmentation_widget.image_path_line.setText(
         str(seg_path)
     )
@@ -502,11 +451,16 @@ def test_geff_import_3d_with_segmentation(
     # Verify tracks were imported successfully
     assert hasattr(dialog, "tracks"), "Dialog should have tracks attribute after import"
     assert dialog.tracks is not None, "Tracks should not be None"
-    assert dialog.tracks.graph.num_nodes() == solution_tracks_3d.graph.num_nodes()
-    assert dialog.tracks.graph.num_edges() == solution_tracks_3d.graph.num_edges()
-    assert dialog.tracks.ndim == 4
+    assert dialog.tracks.graph.num_nodes() == graph.num_nodes()
+    assert dialog.tracks.graph.num_edges() == graph.num_edges()
+    assert dialog.tracks.ndim == ndim
     for node_id in dialog.tracks.graph.node_ids():
         dialog.tracks.get_time(node_id)
+
+    # Area should be enabled and computed when segmentation is present
+    assert "area" in dialog.tracks.features
+    for node_id in dialog.tracks.graph.node_ids():
+        assert dialog.tracks.graph.nodes[node_id]["area"] > 0
 
 
 def test_geff_import_without_area_computes_area(
@@ -780,12 +734,30 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
     tracks = Tracks(graph_2d, ndim=3, time_attr="t")
     geff_path = tmp_path / "old_geff_with_related.zarr"
     # save_segmentation=True writes segmentation + adds related_objects to geff metadata.
-    # seg_label_attr=None preserves node IDs as pixel values (consistent with other tests).
+    # seg_relabel=None preserves node IDs as pixel values (consistent with other tests).
     export_to_geff(tracks, geff_path, save_segmentation=True, seg_relabel=None)
 
-    # Remove segmentation_shape to simulate old funtracks export
+    # Simulate an old GEFF that has related_objects but no embedded mask/bbox
+    # or FeatureDict (these are features of newer funtracks exports).
+    import shutil
+
     root = zarr.open_group(geff_path / "tracks.geff", mode="r+")
     del root.attrs["segmentation_shape"]
+
+    geff_meta = dict(root.attrs["geff"])
+    node_props_meta = dict(geff_meta["node_props_metadata"])
+    for key in ("mask", "bbox"):
+        node_props_meta.pop(key, None)
+    geff_meta["node_props_metadata"] = node_props_meta
+    extra = dict(geff_meta.get("extra", {}))
+    extra.pop("funtracks", None)
+    geff_meta["extra"] = extra
+    root.attrs["geff"] = geff_meta
+
+    for key in ("mask", "bbox"):
+        prop_path = geff_path / "tracks.geff" / "nodes" / "props" / key
+        if prop_path.exists():
+            shutil.rmtree(prop_path)
 
     dialog = ImportDialog(import_type="geff")
     qtbot.addWidget(dialog)
@@ -793,11 +765,12 @@ def test_geff_import_with_related_data(qtbot, tmp_path, graph_2d, monkeypatch):
 
     assert dialog.import_widget.root is not None
 
-    # Old GEFF warning visible; related radio buttons populated
-    assert not dialog.segmentation_widget._old_geff_warning_label.isHidden()
+    # Old GEFF warning should NOT be shown (no mask/bbox columns)
+    assert dialog.segmentation_widget._old_geff_warning_label.isHidden()
+    # Related radio buttons populated from related_objects metadata
     assert len(dialog.segmentation_widget.related_object_radio_buttons) > 0
 
-    # Related radio is auto-checked → include_seg() is True
+    # Related radio is auto-checked -> include_seg() is True
     assert dialog.segmentation_widget.include_seg() is True
 
     # Resolved path must exist on disk


### PR DESCRIPTION
- Remove the "solution" feature from the Groups widget (for backward compatibility) - @AnniekStok if we want this back we would need to update a bunch of tests (right now everything is in the solution group so I don't think it's useful....) 
- Replace solution value `1` with `True` in all test fixtures to match new Boolean type
- Default tracklet id is "tracklet_id" - update Tracks constructors or other asserts as needed
- Use a fixture without mask/bbox on graph to test external seg import - we disallow uploading external seg if the graph has mask/bbox attrs