### PR TITLE
Fix colliding features widges in import menu

### DIFF
--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -303,13 +303,10 @@ class StandardFieldMapWidget(QWidget):
             attribute (str): The attribute name to add as an optional feature
         """
 
-        # Compute the row index based on the current state of the layout, skipping already
-        # present widgets and header row, to prevent stacking widgets on top of each other.
-        row_idx = 1
-        for i, attr in enumerate(self.props_left):
-            if attr == attribute:
-                row_idx = i + 1  # +1 for header row
-                break
+        # Use the QGridLayout row count to assign a new row. Indices will keep counting up
+        # as widgets are removed and added back, but this does not leave holes, and
+        # ensures that two widgets will never collide together on the same row
+        row_idx = self.optional_mapping_layout.rowCount()
 
         # Prop checkbox
         attr_checkbox = QCheckBox(attribute)
@@ -385,7 +382,6 @@ class StandardFieldMapWidget(QWidget):
         self.optional_features[attribute]["recompute"].deleteLater()
 
         del self.optional_features[attribute]
-        self.row_idx = len(self.optional_features)
 
     def _check_for_duplicates(self) -> None:
         """Check if any regionprops property is assigned twice in optional_features


### PR DESCRIPTION
Problem: the `optional_mapping_layout` is not updating correctly on repeated switching of the selected features, which may lead to two widgets being placed on top of each other: 

<img width="402" height="73" alt="image" src="https://github.com/user-attachments/assets/c6ae7089-9485-4a09-9d65-60e4a3a02d70" />

This may lead to import problems because the wrong feature may be assigned to a funtracks Feature. 

The problem is that we are assigning features to a specific row index, while a QGridLayout actually never shrinks after one of its widgets have been removed, so we may assign a new widget to a row that is actually not free. 

To solve this, we should always use the `QGridLayout rowCount` for the new row index. While the row count may become higher then the number of widgets in it, this does not lead to holes because empty rows are automatically collapsed and are not visible.
