### PR TITLE
Fix increasing point size bug

### DIFF
--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -12,6 +12,7 @@ from funtracks.user_actions import UserAddNode, UserDeleteNodes, UserUpdateNodes
 from napari.layers.points._points_mouse_bindings import select
 from napari.utils.notifications import show_info
 from psygnal import Signal
+from psygnal.containers import Selection
 
 from motile_tracker.data_views.keybindings_config import (
     KEYMAP,
@@ -126,6 +127,21 @@ class TrackPoints(ZOnlyPoints):
 
         with self.events.current_size.blocker():
             super().add(coords)
+
+    @property
+    def selected_data(self) -> Selection[int]:
+        """Set of currently selected point indices."""
+
+        return napari.layers.Points.selected_data.fget(self)
+
+    @selected_data.setter
+    def selected_data(self, selected_data) -> None:
+        """Block the current_size event while changing the selection, so that the point
+        size will not accumulate size increases when selecting points.
+        """
+
+        with self.events.current_size.blocker():
+            napari.layers.Points.selected_data.fset(self, selected_data)
 
     def process_click(
         self,

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -97,7 +97,11 @@ sync_filters = {
         },  # we will sync data separately on TrackPoints as we
         # need finer control
         "reverse_exclude": set(get_property_names_from_class(Points))
-        - {"mode", "size", "current_size", "visible"},
+        - {
+            "mode",
+            "visible",
+        },  # Block 'size' and 'current_size' syncing of the enlarged size of a selected
+        # point to the original layer
     },
     TrackLabels: {
         "forward_exclude": {"colormap"},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -317,6 +317,14 @@ def solution_tracks_2d_without_segmentation(
 
 
 @pytest.fixture
+def solution_tracks_3d_without_segmentation(
+    graph_3d_without_segmentation,
+) -> SolutionTracks:
+    """Return a SolutionTracks object wrapping graph_3d_without_segmentation."""
+    return SolutionTracks(graph=graph_3d_without_segmentation, ndim=4, time_attr="t")
+
+
+@pytest.fixture
 def segmentation_2d(graph_2d):
     return np.asarray(Tracks(graph_2d, ndim=3, time_attr="t").segmentation)
 

--- a/tests/data_views/test_ortho_views.py
+++ b/tests/data_views/test_ortho_views.py
@@ -104,3 +104,54 @@ def test_ortho_views(viewer, qtbot, solution_tracks_3d_with_division):
     )
 
     m.cleanup()
+
+
+def test_point_size_stable_when_editing_in_ortho_views(
+    viewer, qtbot, solution_tracks_3d_without_segmentation, monkeypatch
+):
+    """Adding or selecting points in an orthogonal view must not change the point size.
+
+    Selected points are drawn 30% larger, and napari copies the size of a selected point
+    into current_size, which TrackPoints reads as a size slider change. Every add or
+    selection made in an orthogonal view therefore used to grow the points by another
+    30% (5 -> 7 -> 10 -> 13 -> ...).
+    """
+
+    monkeypatch.setattr(
+        "motile_tracker.data_views.views.layers.track_points.confirm_force_operation",
+        lambda message: (True, False),
+    )
+
+    m = initialize_ortho_views(viewer)
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(
+        tracks=solution_tracks_3d_without_segmentation, name="test"
+    )
+    m.show()
+    qtbot.waitUntil(lambda: m.is_shown(), timeout=1000)
+
+    points_layer = tracks_viewer.tracking_layers.points_layer
+    right = m.right_widget.vm_container.viewer_model.layers[points_layer.name]
+    bottom = m.bottom_widget.vm_container.viewer_model.layers[points_layer.name]
+    default_size = points_layer.default_size
+
+    # adding points in an orthogonal view
+    for i in range(4):
+        right.add(np.array([0, 20, 55 + i, 65 + i], dtype=float))
+        assert points_layer.default_size == default_size
+
+    # selecting points, in an orthogonal view and in the main viewer
+    for index in range(3):
+        bottom.selected_data = {index}
+    assert points_layer.default_size == default_size
+    for node in tracks_viewer.tracks.graph.node_ids()[:3]:
+        tracks_viewer.selected_nodes.add(node, False)
+    assert points_layer.default_size == default_size
+
+    # a real size change still works, and reaches the orthogonal views
+    points_layer.current_size = default_size + 3
+    assert points_layer.default_size == default_size + 3
+    for copied_layer in (right, bottom):
+        assert np.array_equal(copied_layer.size, points_layer.size)
+
+    m.cleanup()

--- a/tests/data_views/test_track_points.py
+++ b/tests/data_views/test_track_points.py
@@ -96,8 +96,9 @@ def test_add_blocks_current_size_event(viewer, solution_tracks_2d):
         coords = [0, 10, 20]
         points_layer.add(coords)
 
-        # Verify blocker was called
-        mock_blocker.assert_called_once()
+        # Verify blocker was called. It is used more than once: adding also selects the
+        # new point, and selecting blocks the event as well (see selected_data).
+        assert mock_blocker.called
 
 
 def test_process_click(viewer, solution_tracks_2d, click_node):


### PR DESCRIPTION
Fix increasing point size by blocking reverse sync of point size, and block the current_size syncing when points are selected via selected_data.

closes #471 

Root cause:
napari's Points.selected_data setter copies the size of the selected point into current_size and emits the event — and update_point_outline draws selected points 30% larger. TrackPoints reads any current_size event as "user moved the size slider" (set_point_size), so each selection fed the enlarged size back as the new default: 5 → 7 → 10 → 13 → 17. Two independent routes delivered it: the ortho container assigning orig_layer.selected_data = copied_layer.selected_data, and current_size being reverse-synced from the copy.