### PR TITLE
Clean up table and tree view widgets when their menus are closed

### DIFF
--- a/src/motile_tracker/application_menus/menu_manager.py
+++ b/src/motile_tracker/application_menus/menu_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 from typing import Any
 
 import napari
@@ -27,6 +28,8 @@ class MenuManager:
         )  # names of widgets ever initialized
         self.visible_menus: set[str] = set()  # names of widgets currently visible
         self.active_tabs: list[str] = []  # names of foreground tabs
+        # name -> the scroll wrapper we docked, so we can destroy it again
+        self.menu_widgets: dict[str, QScrollArea] = {}
 
     def initialize_menu(self, menu: dict[str, dict[str, Any]]) -> None:
         """Initialize the menu by creating and adding the specified widgets, with robust
@@ -53,11 +56,17 @@ class MenuManager:
                 location = config["location"]
                 widget = widget_cls(self.viewer)
                 scroll_wrapper = self._create_scroll_wrapper(widget)
-                self.viewer.window.add_dock_widget(
+                dock_widget = self.viewer.window.add_dock_widget(
                     scroll_wrapper, area=location, name=name, tabify=True
                 )
                 self.initialized_menu_widgets.add(name)
                 self.visible_menus.add(name)
+                self.menu_widgets[name] = scroll_wrapper
+                # Clicking the 'x' on a tab makes napari drop the QDockWidget but only
+                # *detach* our widget, so connect it to properly destroy it ourselves
+                dock_widget.destroyed.connect(
+                    lambda *_, menu_name=name: self._on_dock_destroyed(menu_name)
+                )
 
         for tb in self.viewer.window._qt_window.findChildren(QTabBar):
             tb.setUsesScrollButtons(True)
@@ -67,6 +76,39 @@ class MenuManager:
                     min-width: 50px;
                 }
             """)
+
+    def destroy_menu_widget(self, name: str) -> None:
+        """Destroy a menu widget and everything it holds on to.
+
+        Clicking the 'x' on a tab calls napari's ``remove_dock_widget``, which deletes
+        the QDockWidget but leaves the widget behind as a parentless orphan: it stays
+        alive for as long as anything still references it and keeps reacting to
+        TracksViewer signals (rebuilding the tree, re-filling the table) with nothing to
+        show it in. By giving the widget a `cleanup` method, we can properly disconnect
+        from these signals and remove it.
+        """
+        scroll_wrapper = self.menu_widgets.pop(name, None)
+        self.initialized_menu_widgets.discard(name)
+        self.visible_menus.discard(name)
+        if name in self.active_tabs:
+            self.active_tabs.remove(name)
+        if scroll_wrapper is None:
+            return
+
+        try:
+            widget = scroll_wrapper.widget()
+        except RuntimeError:
+            return  # already deleted along with its parent
+        cleanup = getattr(widget, "cleanup", None)  # check if widget has cleanup method
+        if callable(cleanup):
+            cleanup()
+        scroll_wrapper.setParent(None)
+        scroll_wrapper.deleteLater()
+
+    def _on_dock_destroyed(self, name: str) -> None:
+        """Call the menu widget's cleanup method when its dock is destroyed"""
+        with contextlib.suppress(RuntimeError):
+            self.destroy_menu_widget(name)
 
     def _find_dock_widget_by_name(self, name: str) -> QScrollArea | None:
         """Find a widget in the dock dock by name, or return None if not found or

--- a/src/motile_tracker/data_views/views/table/custom_table_widget.py
+++ b/src/motile_tracker/data_views/views/table/custom_table_widget.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import napari
 import numpy as np
 import pandas as pd
@@ -357,6 +359,21 @@ class ColoredTableWidget(QWidget):
         )
         self.tracks_viewer.node_selection_updated.connect(self._update_selected)
         self.tracks_viewer.center_node.connect(self.scroll_to_node)
+
+    def cleanup(self) -> None:
+        """Stop following the TracksViewer.
+
+        Called by MenuManager when the dock is destroyed, so we can stop listening to
+        TracksViewer update signals to rebuild the table.
+        """
+        self.tracks_viewer.table_widget_present = False
+        for signal, slot in (
+            (self.tracks_viewer.tracks_updated, self.update_data),
+            (self.tracks_viewer.node_selection_updated, self._update_selected),
+            (self.tracks_viewer.center_node, self.scroll_to_node),
+        ):
+            with contextlib.suppress(ValueError, KeyError, RuntimeError):
+                signal.disconnect(slot)
 
     def update_data(self, **kwargs) -> None:
         """Update the displayed data based on the tracks_df on TracksViewer"""

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -1,5 +1,6 @@
 # do not put the from __future__ import annotations as it breaks the injection
 
+import contextlib
 from typing import Any
 
 import napari
@@ -562,6 +563,19 @@ class TreeWidget(QWidget):
 
         self.setLayout(layout)
         self._update_track_data(reset_view=True)
+
+    def cleanup(self) -> None:
+        """Called by MenuManager to disconnect from the TracksViewer signals to stop
+        updating the tree.
+        """
+        self.tracks_viewer.tree_widget_present = False
+        for signal, slot in (
+            (self.tracks_viewer.node_selection_updated, self._update_selected),
+            (self.tracks_viewer.tracks_updated, self._update_track_data),
+            (self.tracks_viewer.center_node, self.tree_widget.center_on_node),
+        ):
+            with contextlib.suppress(ValueError, KeyError, RuntimeError):
+                signal.disconnect(slot)
 
     def keyPressEvent(self, event: QKeyEvent) -> None:
         """Handle key press events.

--- a/tests/application_menus/test_menu_manager.py
+++ b/tests/application_menus/test_menu_manager.py
@@ -1,7 +1,5 @@
 """Tests for MenuManager: initialization, tab management, and widget visibility."""
 
-import gc
-import weakref
 from unittest.mock import MagicMock
 
 from qtpy.QtWidgets import QDockWidget, QScrollArea, QTabBar, QWidget
@@ -153,12 +151,17 @@ def test_foreground_tabs_and_tabbar_fallback(make_napari_viewer):
 class CleanupWidget(QWidget):
     """DummyWidget that records that MenuManager gave it a chance to clean up."""
 
+    count = 0
+    cleaned_up: list[str] = []  # names of the widgets whose cleanup() ran
+
     def __init__(self, viewer):
         super().__init__()
-        self.cleaned = 0
+        CleanupWidget.count += 1
+        self.name = f"widget-{CleanupWidget.count}"
 
     def cleanup(self):
-        self.cleaned += 1
+        # kept on the class: the widget itself is deleted right after this
+        CleanupWidget.cleaned_up.append(self.name)
 
 
 def test_dock_close_destroys_widget(make_napari_viewer, qtbot):
@@ -170,25 +173,24 @@ def test_dock_close_destroys_widget(make_napari_viewer, qtbot):
     """
     viewer = make_napari_viewer()
     manager = MenuManager(viewer)
+    CleanupWidget.cleaned_up.clear()
 
     menu = {"TestWidget": {"widget": CleanupWidget, "location": "right"}}
     manager.initialize_menu(menu)
-    wrapper = manager.menu_widgets["TestWidget"]
-    widget = wrapper.widget()
-    widget_ref = weakref.ref(widget)
+    widget = manager.menu_widgets["TestWidget"].widget()
+    name = widget.name
 
     dock = viewer.window._wrapped_dock_widgets["TestWidget"]
-    dock.destroyOnClose()  # what the tab's close button calls
-    qtbot.wait(10)
+    # `destroyed` is emitted once the widget is really gone, which takes a couple of
+    # deferred deletions: waiting for the signal instead of a fixed delay keeps this
+    # independent of how promptly a platform gets round to them.
+    with qtbot.waitSignal(widget.destroyed, timeout=5000):
+        dock.destroyOnClose()  # what the tab's close button calls
 
-    assert widget.cleaned == 1
+    assert CleanupWidget.cleaned_up == [name]
     assert "TestWidget" not in manager.menu_widgets
     assert "TestWidget" not in manager.initialized_menu_widgets
     assert "TestWidget" not in manager.visible_menus
-
-    del wrapper, widget
-    gc.collect()
-    assert widget_ref() is None  # really gone, not just undocked
 
 
 def test_closing_the_viewer_does_not_raise(make_napari_viewer, qtbot):
@@ -205,9 +207,14 @@ def test_closing_the_viewer_does_not_raise(make_napari_viewer, qtbot):
             "WidgetB": {"widget": CleanupWidget, "location": "right"},
         }
     )
+    docks_destroyed = []
+    for name in ("WidgetA", "WidgetB"):
+        viewer.window._wrapped_dock_widgets[name].destroyed.connect(
+            lambda *_: docks_destroyed.append(1)
+        )
 
     viewer.close()
-    qtbot.wait(10)
+    qtbot.waitUntil(lambda: len(docks_destroyed) == 2, timeout=5000)
 
 
 def test_real_menu_widgets_stop_following_tracks_viewer(make_napari_viewer, qtbot):
@@ -222,14 +229,15 @@ def test_real_menu_widgets_stop_following_tracks_viewer(make_napari_viewer, qtbo
     )
 
     tree_widget = manager.menu_widgets["Lineage View"].widget()
+    table_widget = manager.menu_widgets["Table"].widget()
     tracks_viewer = tree_widget.tracks_viewer
     assert tracks_viewer.tree_widget_present
     assert tracks_viewer.table_widget_present
     connected = len(tracks_viewer.tracks_updated)
 
-    for name in ("Lineage View", "Table"):
-        viewer.window._wrapped_dock_widgets[name].destroyOnClose()
-    qtbot.wait(10)
+    for name, widget in (("Lineage View", tree_widget), ("Table", table_widget)):
+        with qtbot.waitSignal(widget.destroyed, timeout=5000):
+            viewer.window._wrapped_dock_widgets[name].destroyOnClose()
 
     assert not tracks_viewer.tree_widget_present
     assert not tracks_viewer.table_widget_present

--- a/tests/application_menus/test_menu_manager.py
+++ b/tests/application_menus/test_menu_manager.py
@@ -1,10 +1,12 @@
 """Tests for MenuManager: initialization, tab management, and widget visibility."""
 
+import gc
+import weakref
 from unittest.mock import MagicMock
 
 from qtpy.QtWidgets import QDockWidget, QScrollArea, QTabBar, QWidget
 
-from motile_tracker.application_menus.main_app import StartupWidget
+from motile_tracker.application_menus.main_app import MENU_WIDGETS, StartupWidget
 from motile_tracker.application_menus.menu_manager import MenuManager
 
 
@@ -146,3 +148,95 @@ def test_foreground_tabs_and_tabbar_fallback(make_napari_viewer):
     for tb in tabbars:
         tb.setStyleSheet.assert_called()
         tb.setElideMode.assert_called()
+
+
+class CleanupWidget(QWidget):
+    """DummyWidget that records that MenuManager gave it a chance to clean up."""
+
+    def __init__(self, viewer):
+        super().__init__()
+        self.cleaned = 0
+
+    def cleanup(self):
+        self.cleaned += 1
+
+
+def test_dock_close_destroys_widget(make_napari_viewer, qtbot):
+    """The 'x' on a tab must destroy the widget, not just orphan it.
+
+    napari's remove_dock_widget deletes the QDockWidget but only detaches the widget
+    it contained (setParent(None)), so without MenuManager destroying it the widget
+    lives on and keeps reacting to TracksViewer signals.
+    """
+    viewer = make_napari_viewer()
+    manager = MenuManager(viewer)
+
+    menu = {"TestWidget": {"widget": CleanupWidget, "location": "right"}}
+    manager.initialize_menu(menu)
+    wrapper = manager.menu_widgets["TestWidget"]
+    widget = wrapper.widget()
+    widget_ref = weakref.ref(widget)
+
+    dock = viewer.window._wrapped_dock_widgets["TestWidget"]
+    dock.destroyOnClose()  # what the tab's close button calls
+    qtbot.wait(10)
+
+    assert widget.cleaned == 1
+    assert "TestWidget" not in manager.menu_widgets
+    assert "TestWidget" not in manager.initialized_menu_widgets
+    assert "TestWidget" not in manager.visible_menus
+
+    del wrapper, widget
+    gc.collect()
+    assert widget_ref() is None  # really gone, not just undocked
+
+
+def test_closing_the_viewer_does_not_raise(make_napari_viewer, qtbot):
+    """Docks destroyed with their window must not trip the destroyed handler.
+
+    Their children are gone by then, so there is nothing left to clean up - it just
+    has to stay quiet, since an exception raised from a Qt signal aborts the process.
+    """
+    viewer = make_napari_viewer()
+    manager = MenuManager(viewer)
+    manager.initialize_menu(
+        {
+            "WidgetA": {"widget": CleanupWidget, "location": "right"},
+            "WidgetB": {"widget": CleanupWidget, "location": "right"},
+        }
+    )
+
+    viewer.close()
+    qtbot.wait(10)
+
+
+def test_real_menu_widgets_stop_following_tracks_viewer(make_napari_viewer, qtbot):
+    """Destroying the docks unhooks the tree and table from the TracksViewer."""
+    viewer = make_napari_viewer()
+    manager = MenuManager(viewer)
+    manager.initialize_menu(
+        {
+            "Lineage View": MENU_WIDGETS["Lineage View"],
+            "Table": MENU_WIDGETS["Table"],
+        }
+    )
+
+    tree_widget = manager.menu_widgets["Lineage View"].widget()
+    tracks_viewer = tree_widget.tracks_viewer
+    assert tracks_viewer.tree_widget_present
+    assert tracks_viewer.table_widget_present
+    connected = len(tracks_viewer.tracks_updated)
+
+    for name in ("Lineage View", "Table"):
+        viewer.window._wrapped_dock_widgets[name].destroyOnClose()
+    qtbot.wait(10)
+
+    assert not tracks_viewer.tree_widget_present
+    assert not tracks_viewer.table_widget_present
+    assert len(tracks_viewer.tracks_updated) == connected - 2
+    tracks_viewer.tracks_updated.emit(True)  # must not reach the destroyed widgets
+
+    # re-opening gives fresh, working widgets
+    manager.initialize_menu({"Lineage View": MENU_WIDGETS["Lineage View"]})
+    assert manager.menu_widgets["Lineage View"].widget() is not tree_widget
+    assert tracks_viewer.tree_widget_present


### PR DESCRIPTION
When you click the 'x' to close a widget in napari, it is removed but not destroyed. The tree view and table view keep listening to the TracksViewer, so they are still updating themselves, even though they are no longer shown. We can give them a cleanup method to disconnect from TracksViewer signals, and then properly destroy the widget. They can still be reinitialized from the plugins menu. The 'eye' button to hide a widget without destroying is unaffected by this. 