### PR TITLE
Scale points layer to world coordinates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2.1.0-a3,<3",
+    "funtracks @ git+https://github.com/funkelab/funtracks.git@refs/pull/262/head",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/src/motile_tracker/application_menus/feature_widget.py
+++ b/src/motile_tracker/application_menus/feature_widget.py
@@ -11,11 +11,93 @@ from qtpy.QtWidgets import (
     QCheckBox,
     QGroupBox,
     QLabel,
+    QMessageBox,
+    QPushButton,
     QVBoxLayout,
     QWidget,
 )
 
 from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+from motile_tracker.import_export.menus.scale_widget import ScaleWidget
+
+
+class ConfirmableScaleWidget(ScaleWidget):
+    """Scale widget with a button to confirm and apply a new scale to the tracks."""
+
+    def __init__(self, viewer: napari.Viewer):
+        super().__init__()
+
+        self.viewer = viewer
+        self.tracks_viewer = TracksViewer.get_instance(viewer)
+        self.tracks_viewer.tracks_updated.connect(self.update_scale_from_tracks)
+
+        self.label = QLabel(
+            "*Changing the scale factors will recompute the activated features and adjust the scaling of the napari layers.*"
+        )
+        self.label.setWordWrap(True)
+        self.label.setTextFormat(Qt.MarkdownText)
+
+        self.confirm_scale_btn = QPushButton("Confirm")
+        self.confirm_scale_btn.setToolTip(
+            "Apply this scale to the tracks: rescales the layers and recomputes the "
+            "measurements that are expressed in world units."
+        )
+        self.confirm_scale_btn.clicked.connect(self.update_scale_on_tracks)
+        self.layout().insertWidget(0, self.label)
+        self.layout().addWidget(self.confirm_scale_btn)
+
+        # load the scaling from tracks, if available
+        self.update_scale_from_tracks()
+
+    def _tracks_scale(self) -> list[float] | None:
+        """The scale of the currently displayed tracks, as a list of floats.
+
+        Tracks without a scale are unscaled, which is a scale of 1 per dimension.
+        Returns None if there are no tracks to read a scale from.
+        """
+
+        tracks = self.tracks_viewer.tracks
+        if tracks is None:
+            return None
+        if tracks.scale is None:
+            return [1.0] * tracks.ndim
+        return [float(s) for s in tracks.scale]
+
+    def update_scale_from_tracks(self, _refresh_view: bool | None = None) -> None:
+        """Prefill the spin boxes with the scale of the currently displayed tracks."""
+
+        scale = self._tracks_scale()
+        if scale is None:
+            self.setVisible(False)
+            return
+
+        if scale == self.scale:
+            return
+
+        self.update(incl_z=len(scale) > 3, scale=scale)
+
+    def update_scale_on_tracks(self) -> None:
+        """Apply the scale in the spin boxes to the tracks."""
+
+        tracks = self.tracks_viewer.tracks
+        scale = self.get_scale()
+        if tracks is None or scale is None:
+            return
+
+        try:
+            tracks.update_scale(scale)
+        except Exception as error:  # noqa: BLE001 - reported to the user below
+            QMessageBox.warning(
+                self,
+                "Cannot apply this scale",
+                f"The scale was not applied and the tracks are unchanged:\n\n{error}"
+                "\n\nNote that perimeter, and the circularity derived from it, can "
+                "only be measured when y and x are scaled equally. Disable those "
+                "features to use an anisotropic scale.",
+            )
+            # the spin boxes still show the rejected values, put the real scale back
+            self.scale = None
+            self.update_scale_from_tracks()
 
 
 class FeatureWidget(QWidget):
@@ -126,3 +208,20 @@ class FeatureWidget(QWidget):
             self.tracks_viewer.tracks_updated.emit(False)
         finally:
             self._toggling = False
+
+
+class FeatureScaleWidget(QWidget):
+    """The feature selection and the scale widget, combined into one menu."""
+
+    def __init__(self, viewer: napari.Viewer):
+        super().__init__()
+
+        self.feature_widget = FeatureWidget(viewer)
+        self.scale_widget = ConfirmableScaleWidget(viewer)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.feature_widget)
+        layout.addWidget(self.scale_widget)
+        layout.addStretch()
+
+        self.setLayout(layout)

--- a/src/motile_tracker/application_menus/main_app.py
+++ b/src/motile_tracker/application_menus/main_app.py
@@ -9,7 +9,7 @@ from qtpy.QtWidgets import (
 from motile_tracker.application_menus.editing_selection_menu import (
     EditingSelectionWidget,
 )
-from motile_tracker.application_menus.feature_widget import FeatureWidget
+from motile_tracker.application_menus.feature_widget import FeatureScaleWidget
 from motile_tracker.application_menus.group_widget import GroupWidget
 from motile_tracker.application_menus.menu_manager import MenuManager
 from motile_tracker.application_menus.track_list_widget import TrackListWidget
@@ -30,7 +30,7 @@ MENU_WIDGETS = {
     "Tracks List": {"widget": TrackListWidget, "location": "right"},
     "Editing && Selection": {"widget": EditingSelectionWidget, "location": "right"},
     "Visualization": {"widget": VisualizationWidget, "location": "right"},
-    "Features": {"widget": FeatureWidget, "location": "right"},
+    "Features": {"widget": FeatureScaleWidget, "location": "right"},
     "Groups": {"widget": GroupWidget, "location": "right"},
     "Table": {"widget": ColoredTableWidget, "location": "right"},
     "Lineage View": {"widget": TreeWidget, "location": "bottom"},

--- a/src/motile_tracker/data_views/views/layers/track_graph.py
+++ b/src/motile_tracker/data_views/views/layers/track_graph.py
@@ -108,6 +108,7 @@ class TrackGraph(napari.layers.Tracks):
             data=track_data,
             graph=track_edges,
             name=name,
+            scale=self.tracks_viewer.tracks.scale,
             tail_length=3,
             color_by="track_id",
         )

--- a/src/motile_tracker/data_views/views/layers/track_points.py
+++ b/src/motile_tracker/data_views/views/layers/track_points.py
@@ -80,6 +80,7 @@ class TrackPoints(ZOnlyPoints):
         super().__init__(
             data=points,
             name=name,
+            scale=tracks_viewer.tracks.scale,
             symbol=symbols,
             face_color=colors,
             size=self.default_size,

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import napari
+import numpy as np
 from funtracks.data_model import Tracks
 from napari.experimental import link_layers, unlink_layers
 
@@ -117,12 +118,26 @@ class TracksLayerGroup:
 
     def _refresh(self) -> None:
         """Refresh the tracking layers with new tracks info"""
+        self._sync_scale()
         if self.tracks_layer is not None:
             self.tracks_layer._refresh()
         if self.seg_layer is not None:
             self.seg_layer._refresh()
         if self.points_layer is not None:
             self.points_layer._refresh()
+
+    def _sync_scale(self) -> None:
+        """Sync the layer scales in case tracks.scale was updated."""
+
+        if self.tracks is None or self.tracks.scale is None:
+            return
+
+        scale = np.asarray(self.tracks.scale, dtype=float)
+        for layer in (self.tracks_layer, self.points_layer, self.seg_layer):
+            if layer is None:
+                continue
+            if not np.array_equal(np.asarray(layer.scale, dtype=float), scale):
+                layer.scale = scale
 
     def update_visible(self, visible_nodes: list[int] | str):
         if self.seg_layer is not None:

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -140,6 +140,37 @@ class TracksLayerGroup:
                 )
             self.tracks_layer.update_track_visibility(visible_tracks)
 
+    def _to_world(self, location: list[float]) -> list[float]:
+        """Convert a pixel-coordinate location (including time) to world units.
+
+        funtracks keeps node positions in pixel coordinates and carries the voxel
+        size in ``tracks.scale``; napari's viewer state (dims.point, camera center,
+        corner pixels) is all in world coordinates.
+        """
+        scale = getattr(self.tracks, "scale", None)
+        if scale is None:
+            return list(location)
+        return [float(c) * float(s) for c, s in zip(location, scale, strict=True)]
+
+    def _visible_world_range(self) -> tuple[float, float, float, float]:
+        """World bounds (min_y, max_y, min_x, max_x) of what the canvas is showing.
+
+        Derived from the camera, the same way the orthogonal views decide
+        whether a coordinate is in view. camera.center is in display order, so its
+        last two entries are the displayed y and x axes.
+        """
+        viewbox = self.viewer._get_viewbox_size()
+        zoom = self.viewer.camera.zoom
+        center = self.viewer.camera.center
+        half_height = viewbox[0] / zoom / 2
+        half_width = viewbox[1] / zoom / 2
+        return (
+            center[-2] - half_height,
+            center[-2] + half_height,
+            center[-1] - half_width,
+            center[-1] + half_width,
+        )
+
     def center_view(self, node):
         """Adjust the current_step and camera center of the viewer to jump to the node
         location, if the node is not already in the field of view"""
@@ -151,18 +182,17 @@ class TracksLayerGroup:
                 f"{self.viewer.dims.ndim}"
             )
 
+            # The graph stores pixel coordinates; everything below (dims.point,
+            # camera.center, visible range) works in world coordinates.
+            location = self._to_world(location)
+
             # Set dims.point directly with world coordinates - napari will
             # automatically convert to the correct step indices
             self.viewer.dims.point = location
 
             # check whether the new coordinates are inside or outside the field of view,
             # then adjust the camera if needed
-            example_layer = (
-                self.points_layer
-            )  # the points layer is always in world units,
-            # because it directly reads the scaled coordinates. Therefore, no rescaling
-            # is necessary to compute the camera center
-            corner_coordinates = example_layer.corner_pixels
+            _min_y, _max_y, _min_x, _max_x = self._visible_world_range()
 
             # check which dimensions are shown, the first dimension is displayed on the
             # x axis, and the second on the y_axis
@@ -178,13 +208,7 @@ class TracksLayerGroup:
             x_dim = dims_displayed[-1]
             y_dim = dims_displayed[-2]
 
-            # find corner pixels for the displayed axes
-            _min_x = corner_coordinates[0][x_dim]
-            _max_x = corner_coordinates[1][x_dim]
-            _min_y = corner_coordinates[0][y_dim]
-            _max_y = corner_coordinates[1][y_dim]
-
-            # check whether the node location falls within the corner spatial range
+            # check whether the node location falls within the visible spatial range
             if not (
                 (location[x_dim] > _min_x and location[x_dim] < _max_x)
                 and (location[y_dim] > _min_y and location[y_dim] < _max_y)

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -56,6 +56,7 @@ def copy_layer(layer: Layer, name: str = ""):
         res_layer = ZOnlyPoints(
             data=layer.data,
             name=layer.name,
+            scale=layer.scale,  # the point data is in pixel coordinates
             size=layer.size,  # these are not synced, so copy these properties here to set
             shown=layer.shown,  # the initial size and shown properties correctly.
         )

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget_utils.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget_utils.py
@@ -115,6 +115,34 @@ def extract_sorted_tracks(
         zip(node_ids_list, df_attrs[tracklet_key].to_list(), strict=True)
     )
     feat_cols = {key: df_attrs[key].to_list() for key in node_feature_keys}
+
+    # Positions are stored in pixel coordinates but displayed in world units, so
+    # scale that one column up front rather than at every use site downstream.
+    # tracks.scale is [t, (z), y, x]; only the spatial part applies to a position.
+    scale = getattr(tracks, "scale", None)
+    spatial_scale = None if scale is None else [float(s) for s in scale[1:]]
+    if spatial_scale is not None and all(s == 1.0 for s in spatial_scale):
+        spatial_scale = None  # nothing to convert
+
+    if spatial_scale is not None:
+        position_key = tracks.features.position_key
+        pos_keys = (
+            [position_key]
+            if isinstance(position_key, str)
+            else list(position_key or [])
+        )
+        for i, key in enumerate(pos_keys):
+            if key not in feat_cols:
+                continue
+            if len(pos_keys) == 1:
+                # single column holding the full coordinate array per node
+                feat_cols[key] = [
+                    (np.asarray(val) * spatial_scale).tolist() for val in feat_cols[key]
+                ]
+            else:
+                # one column per axis, in the same order as the scale
+                feat_cols[key] = [val * spatial_scale[i] for val in feat_cols[key]]
+
     node_to_feat = {
         node: {key: feat_cols[key][i] for key in node_feature_keys}
         for i, node in enumerate(node_ids_list)

--- a/src/motile_tracker/import_export/menus/scale_widget.py
+++ b/src/motile_tracker/import_export/menus/scale_widget.py
@@ -37,7 +37,12 @@ class ScaleWidget(QWidget):
         )
         self.setVisible(False)
 
-    def update(self, metadata: dict | None = None, incl_z: bool = False) -> None:
+    def update(
+        self,
+        metadata: dict | None = None,
+        incl_z: bool = False,
+        scale: list[float] | None = None,
+    ) -> None:
         """
         Add widgets to the layout, prefilled from available information if possible
 
@@ -46,11 +51,19 @@ class ScaleWidget(QWidget):
                 information.
             incl_z (bool): whether to include 'z' (provide this if metadata is not
                 available)
+            scale (list[float] | None): an already-resolved scale ([t, (z), y, x]) to
+                prefill with, e.g. read from the scale columns of a CSV. Takes
+                precedence over the geff metadata.
         """
 
         axes = metadata.get("axes") if metadata is not None else None
 
-        if axes:
+        # A scale whose dimensionality disagrees with the one the user picked is
+        # not usable here, so fall through to the other sources.
+        if scale is not None and len(scale) == (4 if incl_z else 3):
+            self.scale = [float(s) for s in scale]
+
+        elif axes:
             lookup = {a["name"].lower(): a.get("scale", 1) or 1 for a in axes}
             self.scale = [1.0] * len(axes)  # time + spatial dims
             self.scale[-1], self.scale[-2] = lookup.get("x", 1), lookup.get("y", 1)
@@ -83,10 +96,11 @@ class ScaleWidget(QWidget):
         """Return a QDoubleSpinBox for scaling values"""
 
         spin_box = QDoubleSpinBox()
-        spin_box.setValue(value)
-        spin_box.setSingleStep(0.1)
+        spin_box.setDecimals(4)
         spin_box.setMinimum(0)
-        spin_box.setDecimals(3)
+        spin_box.setMaximum(1e6)
+        spin_box.setSingleStep(0.1)
+        spin_box.setValue(value)
         return spin_box
 
     def get_scale(self) -> list[float] | None:

--- a/src/motile_tracker/motile/backend/solve.py
+++ b/src/motile_tracker/motile/backend/solve.py
@@ -75,9 +75,9 @@ def solve(
             cand_graph = build_candidate_graph(input_data, solver_params, scale)
 
         if solver_params.window_size is not None:
-            result = _solve_chunked(cand_graph, solver_params, on_solver_update)
+            result = _solve_chunked(cand_graph, solver_params, on_solver_update, scale)
         else:
-            result = _solve_full(cand_graph, solver_params, on_solver_update)
+            result = _solve_full(cand_graph, solver_params, on_solver_update, scale)
 
     if input_data.ndim != 2:
         result._update_metadata(shape=input_data.shape)
@@ -112,9 +112,10 @@ def _solve_full(
     cand_graph: td.graph.GraphView,
     solver_params: SolverParams,
     on_solver_update: Callable | None = None,
+    scale: list | None = None,
 ) -> td.graph.GraphView:
     """Solve the tracking problem on the full candidate graph at once."""
-    solver = construct_solver(cand_graph, solver_params)
+    solver = construct_solver(cand_graph, solver_params, scale)
     start_time = time.time()
     solution = solver.solve(verbose=False, on_event=on_solver_update)
     logger.info("Solution took %.2f seconds", time.time() - start_time)
@@ -134,6 +135,7 @@ def _solve_window(
     window_subgraph: td.graph.GraphView,
     solver_params: SolverParams,
     on_solver_update: Callable | None = None,
+    scale: list | None = None,
 ) -> td.graph.GraphView | None:
     """Solve a single window subgraph.
 
@@ -145,6 +147,7 @@ def _solve_window(
             have the PIN_ATTR attribute set, a Pin constraint will be used.
         solver_params: The solver parameters.
         on_solver_update: Callback for solver progress updates.
+        scale: The scale of the data in each dimension.
 
     Returns:
         The solution graph for this window, or None if the window has no nodes.
@@ -160,7 +163,7 @@ def _solve_window(
         )
         return window_subgraph
 
-    solver = construct_solver(window_subgraph, solver_params)
+    solver = construct_solver(window_subgraph, solver_params, scale)
     start_time = time.time()
     solution = solver.solve(verbose=False, on_event=on_solver_update)
     logger.info("Window solved in %.2f seconds", time.time() - start_time)
@@ -230,7 +233,7 @@ def _solve_single_window(
     )
 
     start_time = time.time()
-    solution = _solve_window(cand_graph, solver_params, on_solver_update)
+    solution = _solve_window(cand_graph, solver_params, on_solver_update, scale)
     logger.info("Single window solution took %.2f seconds", time.time() - start_time)
 
     if solution is None:
@@ -249,6 +252,7 @@ def _solve_chunked(
     cand_graph: td.graph.GraphView,
     solver_params: SolverParams,
     on_solver_update: Callable | None = None,
+    scale: list | None = None,
 ) -> td.graph.GraphView:
     """Solve the tracking problem in chunks using a sliding window approach.
 
@@ -261,6 +265,7 @@ def _solve_chunked(
         cand_graph: The full candidate graph with all nodes and edges.
         solver_params: The solver parameters including window_size and overlap_size.
         on_solver_update: Callback for solver progress updates.
+        scale: The scale of the data in each dimension.
 
     Returns:
         The combined solution graph from all windows.
@@ -327,7 +332,7 @@ def _solve_chunked(
 
         # Solve this window
         window_solution = _solve_window(
-            window_subgraph, solver_params, on_solver_update
+            window_subgraph, solver_params, on_solver_update, scale
         )
 
         if window_solution is None:
@@ -448,7 +453,9 @@ _SKIP_ATTRS = {td.DEFAULT_ATTR_KEYS.MASK, td.DEFAULT_ATTR_KEYS.BBOX}
 
 
 def construct_solver(
-    cand_graph: td.graph.GraphView, solver_params: SolverParams
+    cand_graph: td.graph.GraphView,
+    solver_params: SolverParams,
+    scale: list | None = None,
 ) -> Solver:
     """Construct a motile solver with the parameters specified in the solver
     params object.
@@ -457,6 +464,10 @@ def construct_solver(
         cand_graph (td.graph.GraphView): The candidate graph to use in the solver
         solver_params (SolverParams): The costs and constraints to use in
             the solver
+        scale (list | None): The scale of the data in each dimension (including
+            time). Node positions on the candidate graph are in pixel coordinates,
+            so they are converted to world units before being handed to the
+            solver, keeping the distance costs comparable across anisotropic axes.
 
     Returns:
         Solver: A motile solver with the specified graph, costs, and
@@ -469,9 +480,14 @@ def construct_solver(
     skip_cols = [c for c in node_df.columns if c in _SKIP_ATTRS]
     if skip_cols:
         node_df = node_df.drop(skip_cols)
+    spatial_scale = None
+    if scale is not None and not all(float(s) == 1.0 for s in scale[1:]):
+        spatial_scale = np.asarray(scale[1:], dtype=float)
     node_id_col = td.DEFAULT_ATTR_KEYS.NODE_ID
     for row in node_df.rows(named=True):
         node_id = row.pop(node_id_col)
+        if spatial_scale is not None and "pos" in row:
+            row["pos"] = (np.asarray(row["pos"], dtype=float) * spatial_scale).tolist()
         tg.add_node(node_id, row)
 
     # Bulk-fetch edge attributes (one polars scan instead of N individual scans)

--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -162,11 +162,10 @@ class MotileWidget(QWidget):
                     graph=run.graph, shape=seg_shape, attr_key="node_id", offset=0
                 )
 
-        if run.segmentation is not None and "area" not in run.features:
-            # Area is a default regionprops feature, so a Tracks built with a
-            # segmentation already has it. This covers the case where the
-            # segmentation only became available after construction.
-            run.enable_features(["area"])
+        if run.segmentation is not None:
+            # recompute=False: area values are already on the graph nodes
+            # because compute_graph_from_seg computes area during node extraction.
+            run.enable_features(["area"], recompute=False)
 
         if run.graph.num_nodes() == 0:
             show_warning(

--- a/src/motile_tracker/motile/menus/motile_widget.py
+++ b/src/motile_tracker/motile/menus/motile_widget.py
@@ -162,10 +162,11 @@ class MotileWidget(QWidget):
                     graph=run.graph, shape=seg_shape, attr_key="node_id", offset=0
                 )
 
-        if run.segmentation is not None:
-            # recompute=False: area values are already on the graph nodes
-            # because compute_graph_from_seg computes area during node extraction.
-            run.enable_features(["area"], recompute=False)
+        if run.segmentation is not None and "area" not in run.features:
+            # Area is a default regionprops feature, so a Tracks built with a
+            # segmentation already has it. This covers the case where the
+            # segmentation only became available after construction.
+            run.enable_features(["area"])
 
         if run.graph.num_nodes() == 0:
             show_warning(

--- a/tests/application_menus/test_feature_widget.py
+++ b/tests/application_menus/test_feature_widget.py
@@ -2,10 +2,14 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import numpy as np
 import pytest
 from funtracks.annotators._regionprops_annotator import DEFAULT_POS_KEY
 
-from motile_tracker.application_menus.feature_widget import FeatureWidget
+from motile_tracker.application_menus.feature_widget import (
+    FeatureScaleWidget,
+    FeatureWidget,
+)
 from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
 
 
@@ -162,3 +166,90 @@ def test_update_checkboxes_recreates_widgets(
     ]
 
     assert len(widget_items) == first_count
+
+
+@pytest.fixture
+def scale_widget(make_napari_viewer, solution_tracks_2d):
+    """A ConfirmableScaleWidget on a viewer showing 2D tracks with an area feature."""
+    viewer = make_napari_viewer()
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(solution_tracks_2d, name="test")
+    tracks_viewer.tracks.enable_features(["area"])
+    # the dataframe behind the tree and table views is only kept up to date when one
+    # of those views is present
+    tracks_viewer.tree_widget_present = True
+    tracks_viewer.update_track_df(initialization=False, refresh_view=True)
+
+    # hold on to the combined widget: dropping it deletes its Qt children
+    combined = FeatureScaleWidget(viewer)
+    yield combined.scale_widget, tracks_viewer
+
+
+def _areas(tracks) -> list[float]:
+    return [tracks.get_node_attr(node, "area") for node in tracks.graph_full.node_ids()]
+
+
+def test_scale_widget_prefills_from_tracks(scale_widget):
+    widget, tracks_viewer = scale_widget
+
+    # tracks without a scale are unscaled, and the widget says so rather than hiding
+    assert tracks_viewer.tracks.scale is None
+    assert widget.isVisibleTo(widget.parentWidget())
+    assert widget.get_scale() == [1, 1.0, 1.0]
+    assert not widget.z_spin_box.isVisibleTo(widget)
+
+
+def test_confirm_scale_updates_tracks_layers_and_dataframe(scale_widget):
+    widget, tracks_viewer = scale_widget
+    tracks = tracks_viewer.tracks
+
+    areas_before = _areas(tracks)
+    df_before = tracks_viewer.track_df.copy()
+
+    widget.y_spin_box.setValue(2.0)
+    widget.x_spin_box.setValue(3.0)
+    widget.confirm_scale_btn.click()
+
+    assert tracks.scale == [1.0, 2.0, 3.0]
+
+    # areas are in world units, so they follow the new voxel size
+    for before, after in zip(areas_before, _areas(tracks), strict=True):
+        assert after == pytest.approx(before * 6.0)
+
+    # every napari layer is rescaled
+    layers = tracks_viewer.tracking_layers
+    for layer in (layers.points_layer, layers.tracks_layer, layers.seg_layer):
+        assert layer is not None
+        np.testing.assert_array_equal(layer.scale, [1.0, 2.0, 3.0])
+
+    # and the dataframe behind the tree and table views shows world coordinates
+    df_after = tracks_viewer.track_df
+    np.testing.assert_allclose(df_after["y"], df_before["y"] * 2.0)
+    np.testing.assert_allclose(df_after["x"], df_before["x"] * 3.0)
+    np.testing.assert_allclose(df_after["Area"], df_before["Area"] * 6.0)
+
+    # the spin boxes are rebuilt from the tracks, so they still agree
+    assert widget.get_scale() == [1, 2.0, 3.0]
+
+
+def test_confirm_scale_reports_failure_and_leaves_tracks_alone(
+    scale_widget, monkeypatch
+):
+    """skimage cannot measure a perimeter under anisotropic spacing."""
+    widget, tracks_viewer = scale_widget
+    tracks = tracks_viewer.tracks
+    tracks.enable_features(["perimeter"])
+
+    warned = MagicMock()
+    monkeypatch.setattr(
+        "motile_tracker.application_menus.feature_widget.QMessageBox.warning", warned
+    )
+
+    widget.y_spin_box.setValue(2.0)
+    widget.x_spin_box.setValue(3.0)
+    widget.confirm_scale_btn.click()
+
+    warned.assert_called_once()
+    assert tracks.scale is None
+    # the rejected values are replaced by the scale the tracks actually have
+    assert widget.get_scale() == [1, 1.0, 1.0]

--- a/tests/data_views/test_center_view.py
+++ b/tests/data_views/test_center_view.py
@@ -22,7 +22,7 @@ def _make_single_node_graph(
 
     Args:
         tmp_path: Pytest tmp_path for the SQLite database.
-        pos: Node position in world coordinates [z, y, x].
+        pos: Node position in pixel coordinates [z, y, x].
         seg_bbox: Bounding box [z0, y0, x0, z1, y1, x1] for the node's mask.
             If provided, mask/bbox node attributes and shape metadata
             are added so SolutionTracks can reconstruct the segmentation.
@@ -71,10 +71,11 @@ class TestCenterViewWithScale:
     """Test center_view correctly handles scaled data.
 
     The key thing to understand:
-    - Node positions in the graph are in WORLD coordinates (scaled)
+    - Node positions in the graph are in PIXEL coordinates
     - viewer.dims.point is in WORLD coordinates
     - viewer.dims.current_step is an index into the dims range
-    - center_view should position the viewer at the node's world coordinates
+    - center_view should convert the node position with tracks.scale and position
+      the viewer at the resulting world coordinates
     """
 
     def test_center_view_with_z_scale_less_than_one(self, viewer, tmp_path):
@@ -85,11 +86,11 @@ class TestCenterViewWithScale:
         - Node at world z=5 should display correctly
         """
 
-        # Create graph - positions are in WORLD coordinates
-        # Node at world position [5, 10, 10]; pixel z=10 (box [9:11,9:11,9:11])
+        # Create graph - positions are in PIXEL coordinates
+        # Node at pixel z=10 (box [9:11,9:11,9:11]), i.e. world z=5
         graph = _make_single_node_graph(
             tmp_path,
-            pos=[5, 10, 10],
+            pos=[10, 10, 10],
             seg_bbox=[9, 9, 9, 11, 11, 11],
             seg_shape=(2, 20, 20, 20),
         )
@@ -104,7 +105,6 @@ class TestCenterViewWithScale:
         points_layer = tracks_viewer.tracking_layers.points_layer
         node_index = points_layer.node_index_dict[1]
 
-        # Center on node 1 at world position [25, 50, 50]
         tracks_viewer.tracking_layers.center_view(node=1)
 
         # Verify viewer is positioned at world z=5
@@ -125,10 +125,10 @@ class TestCenterViewWithScale:
         - Segmentation pixel z=5 corresponds to world z=10
         """
 
-        # Node at world position [10, 10, 10]; pixel z=5 (box [4:6,9:11,9:11])
+        # Node at pixel z=5 (box [4:6,9:11,9:11]), i.e. world z=10
         graph = _make_single_node_graph(
             tmp_path,
-            pos=[10, 10, 10],
+            pos=[5, 10, 10],
             seg_bbox=[4, 9, 9, 6, 11, 11],
             seg_shape=(2, 20, 20, 20),
         )
@@ -167,10 +167,10 @@ class TestCenterViewWithScale:
         image_data = np.random.rand(2, 20, 20, 20)
         viewer.add_image(image_data, name="raw_image")
 
-        # Node at world z=5 (box [9:11,9:11,9:11])
+        # Node at pixel z=10 (box [9:11,9:11,9:11]), i.e. world z=5
         graph = _make_single_node_graph(
             tmp_path,
-            pos=[5, 10, 10],
+            pos=[10, 10, 10],
             seg_bbox=[9, 9, 9, 11, 11, 11],
             seg_shape=(2, 20, 20, 20),
         )
@@ -237,7 +237,7 @@ class TestCenterViewWithScale:
         """Test center_view when there is no segmentation, only points and an image layer.
 
         Image layer: scale [1, 0.5, 1, 1], 20 z-pixels -> world z 0-10
-        Points: in world coordinates at z=5
+        Points: in pixel coordinates at z=10, i.e. world z=5
         No segmentation layer.
         """
 
@@ -245,8 +245,8 @@ class TestCenterViewWithScale:
         image_data = np.random.rand(2, 20, 20, 20)
         viewer.add_image(image_data, name="raw_image", scale=[1.0, 0.5, 1.0, 1.0])
 
-        # Node at world position [5, 10, 10] — no segmentation
-        graph = _make_single_node_graph(tmp_path, pos=[5, 10, 10])
+        # Node at pixel position [10, 10, 10] — no segmentation
+        graph = _make_single_node_graph(tmp_path, pos=[10, 10, 10])
 
         tracks = SolutionTracks(
             graph=graph, scale=[1.0, 0.5, 1.0, 1.0], ndim=4, time_attr="t"
@@ -276,7 +276,7 @@ class TestCenterViewWithScale:
         """Test center_view with no segmentation and mismatched image/points scales.
 
         Image layer: scale [1, 1, 1, 1], 20 z-pixels -> world z 0-20
-        Points: scale [1, 0.5, 1, 1], positions at world z=5
+        Points: scale [1, 0.5, 1, 1], positions at pixel z=10, i.e. world z=5
         No segmentation layer.
 
         This tests the case where the image and points have different scales,
@@ -287,8 +287,8 @@ class TestCenterViewWithScale:
         image_data = np.random.rand(2, 20, 20, 20)
         viewer.add_image(image_data, name="raw_image")
 
-        # Node at world position [5, 10, 10] — no segmentation
-        graph = _make_single_node_graph(tmp_path, pos=[5, 10, 10])
+        # Node at pixel position [10, 10, 10] — no segmentation
+        graph = _make_single_node_graph(tmp_path, pos=[10, 10, 10])
 
         tracks = SolutionTracks(
             graph=graph, scale=[1.0, 0.5, 1.0, 1.0], ndim=4, time_attr="t"
@@ -324,10 +324,10 @@ class TestCenterViewWithScale:
         # Initialize orthogonal views
         ortho_manager = initialize_ortho_views(viewer)
 
-        # Node at world position [5, 10, 10] (box [9:11,9:11,9:11])
+        # Node at pixel position [10, 10, 10] (box [9:11,9:11,9:11]), world z=5
         graph = _make_single_node_graph(
             tmp_path,
-            pos=[5, 10, 10],
+            pos=[10, 10, 10],
             seg_bbox=[9, 9, 9, 11, 11, 11],
             seg_shape=(2, 20, 20, 20),
         )
@@ -393,3 +393,113 @@ class TestCenterViewWithScale:
         )
 
         ortho_manager.cleanup()
+
+
+def _make_track_graph(tmp_path, positions: list[tuple[int, int, int]]):
+    """3D+time graph holding one track that walks through the given pixel positions."""
+    graph = create_empty_graphview_graph(
+        node_attributes=[
+            "pos",
+            "area",
+            td.DEFAULT_ATTR_KEYS.MASK,
+            td.DEFAULT_ATTR_KEYS.BBOX,
+        ],
+        ndim=4,
+        database=str(tmp_path / "graph.db"),
+    )
+    nodes = []
+    for t, (z, y, x) in enumerate(positions):
+        bbox = np.array([z - 1, y - 1, x - 1, z + 2, y + 2, x + 2], dtype=np.int64)
+        shape = tuple(int(bbox[i + 3] - bbox[i]) for i in range(3))
+        nodes.append(
+            {
+                "t": t,
+                "pos": [float(z), float(y), float(x)],
+                "area": 27.0,
+                "solution": True,
+                td.DEFAULT_ATTR_KEYS.MASK: Mask(np.ones(shape, dtype=bool), bbox=bbox),
+                td.DEFAULT_ATTR_KEYS.BBOX: bbox,
+            }
+        )
+    ids = list(range(1, len(positions) + 1))
+    graph.bulk_add_nodes(nodes=nodes, indices=ids)
+    graph.bulk_add_edges(
+        [
+            {"source_id": a, "target_id": b, "solution": True}
+            for a, b in zip(ids, ids[1:], strict=False)
+        ]
+    )
+    graph._update_metadata(shape=(len(positions), 60, 600, 600))
+    return graph
+
+
+def test_center_view_does_not_pan_for_a_visible_node(viewer, tmp_path):
+    """Centering on a node that is already on screen must leave the camera alone.
+
+    The in-view check must be against what the canvas is showing. Using
+    ``points_layer.corner_pixels`` does not do that: napari clips those to the
+    layer's own data extent, so they describe the bounding box of the point cloud,
+    and every node on the edge of a track reads as "out of view". The resulting
+    pointless camera pans are what desynchronise napari's cursor.position (which
+    it only refreshes on real mouse events), and the orthogonal views' "T"
+    shortcut then acts on a stale mouse position.
+    """
+    # a track wandering across the middle of the image, so its bounding box is
+    # much smaller than the image and the first/last nodes sit on its edge
+    positions = [(30, 280 + 8 * i, 290 + 6 * i) for i in range(12)]
+    scale = [1.0, 1.0, 0.416, 0.416]
+    tracks = SolutionTracks(
+        graph=_make_track_graph(tmp_path, positions),
+        scale=scale,
+        ndim=4,
+        time_attr="t",
+    )
+
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=tracks, name="test")
+    layers = tracks_viewer.tracking_layers
+
+    # Sit on the middle node, then jump to the ends of the track. The whole track
+    # spans ~37 x 27 world units and the view is far wider, so all of it is on
+    # screen and none of these jumps needs a pan.
+    tracks_viewer.center_on_node(6)
+    for node in (1, len(positions), 6):
+        min_y, max_y, min_x, max_x = layers._visible_world_range()
+        location = layers._to_world(tracks.get_position(node, incl_time=True))
+        y_dim, x_dim = viewer.dims.displayed[-2], viewer.dims.displayed[-1]
+        assert min_y < location[y_dim] < max_y, "test setup: node is off screen"
+        assert min_x < location[x_dim] < max_x, "test setup: node is off screen"
+
+        before = tuple(viewer.camera.center)
+        tracks_viewer.center_on_node(node)
+        assert tuple(viewer.camera.center) == before, (
+            f"centering on visible node {node} panned the camera from {before} to "
+            f"{tuple(viewer.camera.center)}"
+        )
+
+
+def test_center_view_pans_for_an_offscreen_node(viewer, tmp_path):
+    """The counterpart: a node outside the view does still bring the camera along."""
+    positions = [(30, 30, 30), (30, 560, 560)]
+    tracks = SolutionTracks(
+        graph=_make_track_graph(tmp_path, positions),
+        scale=[1.0, 1.0, 0.416, 0.416],
+        ndim=4,
+        time_attr="t",
+    )
+
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=tracks, name="test")
+    layers = tracks_viewer.tracking_layers
+
+    tracks_viewer.center_on_node(1)
+    viewer.camera.zoom = viewer.camera.zoom * 8  # zoom in so node 2 is off screen
+
+    min_y, max_y, _, _ = layers._visible_world_range()
+    location = layers._to_world(tracks.get_position(2, incl_time=True))
+    y_dim = viewer.dims.displayed[-2]
+    assert not (min_y < location[y_dim] < max_y), "test setup: node 2 is on screen"
+
+    before = tuple(viewer.camera.center)
+    tracks_viewer.center_on_node(2)
+    assert tuple(viewer.camera.center) != before

--- a/tests/data_views/test_pixel_coordinates.py
+++ b/tests/data_views/test_pixel_coordinates.py
@@ -1,0 +1,83 @@
+"""Positions are stored in pixels and displayed in world units.
+
+funtracks keeps node positions in pixel coordinates and carries the voxel size
+in ``tracks.scale``. Everything the user sees - the napari canvas, the tree plot
+and the table view - is in world units, so each consumer has to apply that scale
+itself. These tests pin down that split for an anisotropic scale.
+"""
+
+import napari
+import numpy as np
+import pytest
+from funtracks.data_model import Tracks
+
+from motile_tracker.data_views.views.tree_view.tree_widget_utils import (
+    extract_sorted_tracks,
+)
+from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+
+SCALE = [1.0, 2.0, 5.0]  # t, y, x
+
+
+@pytest.fixture(autouse=True)
+def clear_viewer_layers(viewer):
+    """Clear viewer layers between tests."""
+    yield
+    viewer.layers.clear()
+
+
+def _tracks(graph_2d) -> Tracks:
+    return Tracks(graph=graph_2d, ndim=3, time_attr="t", scale=SCALE)
+
+
+def test_layers_carry_the_scale_and_keep_pixel_data(viewer, graph_2d):
+    """The tracking layers hold pixel data plus tracks.scale, like the seg layer."""
+    tracks = _tracks(graph_2d)
+
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=tracks, name="test")
+    layers = tracks_viewer.tracking_layers
+
+    for layer in (layers.points_layer, layers.tracks_layer, layers.seg_layer):
+        np.testing.assert_allclose(layer.scale, SCALE)
+
+    # The points layer data is the unscaled graph position, and napari turns it
+    # into the world coordinate the user sees.
+    nodes = layers.points_layer.nodes
+    np.testing.assert_allclose(
+        layers.points_layer.data, tracks.get_positions(nodes, incl_time=True)
+    )
+    world = layers.points_layer.data_to_world(layers.points_layer.data[0])
+    np.testing.assert_allclose(world, layers.points_layer.data[0] * np.array(SCALE))
+
+
+def test_tree_dataframe_holds_world_positions(graph_2d):
+    """The tree plot and table view show positions in world units."""
+    tracks = _tracks(graph_2d)
+    colormap = napari.utils.colormaps.label_colormap(49, seed=0.5, background_value=0)
+
+    df, _ = extract_sorted_tracks(tracks, colormap)
+
+    node_ids = df["node_id"].to_list()
+    pixel_pos = tracks.get_positions(node_ids)
+    np.testing.assert_allclose(df["y"].to_numpy(), pixel_pos[:, 0] * SCALE[1])
+    np.testing.assert_allclose(df["x"].to_numpy(), pixel_pos[:, 1] * SCALE[2])
+
+    # Only the position is converted: the bounding box indexes the segmentation
+    # and stays in pixels.
+    np.testing.assert_allclose(
+        df["Bounding box_0"].to_numpy(),
+        [tracks.get_node_attr(node, "bbox")[0] for node in node_ids],
+    )
+
+
+def test_tree_dataframe_unscaled_without_scale(graph_2d):
+    """Without a scale the displayed positions are the stored ones."""
+    tracks = Tracks(graph=graph_2d, ndim=3, time_attr="t")
+    colormap = napari.utils.colormaps.label_colormap(49, seed=0.5, background_value=0)
+
+    df, _ = extract_sorted_tracks(tracks, colormap)
+
+    pixel_pos = tracks.get_positions(df["node_id"].to_list())
+    np.testing.assert_allclose(df["y"].to_numpy(), pixel_pos[:, 0])
+    np.testing.assert_allclose(df["x"].to_numpy(), pixel_pos[:, 1])

--- a/tests/motile/backend/test_solver.py
+++ b/tests/motile/backend/test_solver.py
@@ -127,3 +127,35 @@ def test_solve_single_window_invalid_start(segmentation_3d):
 
     with pytest.raises(ValueError, match="beyond last frame"):
         solve(params, segmentation_3d)
+
+
+def test_solve_points_uses_world_distances():
+    """Positions stay in pixels; the scale governs the distance-based decisions.
+
+    The points move 6 pixels along y and 0 along x per frame. With an isotropic
+    scale that is well inside max_edge_distance, but stretching y by 5 puts every
+    link 30 world units apart, beyond the candidate-edge budget, so nothing links
+    up. Either way the solved graph carries the original pixel coordinates.
+    """
+    points = np.array(
+        [
+            [0, 50.0, 50.0],
+            [1, 56.0, 50.0],
+            [2, 62.0, 50.0],
+        ]
+    )
+    params = SolverParams()
+    params.appear_cost = None
+    params.iou_cost = None  # points graphs have no iou edge attribute
+    params.max_edge_distance = 10
+
+    solution = solve(params, points)
+    assert solution.num_edges() == 2
+
+    scaled = solve(params, points, scale=[1.0, 5.0, 1.0])
+    assert scaled.num_edges() == 0
+
+    for graph in (solution, scaled):
+        positions = {node: list(graph.nodes[node]["pos"]) for node in graph.node_ids()}
+        for node, pos in positions.items():
+            np.testing.assert_allclose(pos, points[node][1:])


### PR DESCRIPTION
As discussed in https://github.com/funkelab/funtracks/issues/261, the coordinates are kept in pixel units, and we scale everything on the napari side for visualization purposes:
 - apply the scaling to every layer, including the TrackPoints layer
 - display all measured features, including the centroid, in scaled units in the tree plot and in the table

I will add the scaling widget here as well, so that the user does not have to set the scaling via the console.

Needs https://github.com/funkelab/funtracks/pull/262.