### PR TITLE
Fix stale segmentation when loading tracks from geff or MotileRun

### DIFF
--- a/src/motile_tracker/data_views/views_coordinator/tracks_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_list.py
@@ -69,12 +69,16 @@ def _as_solution_tracks(tracks: Tracks) -> SolutionTracks:
     """
     if isinstance(tracks, SolutionTracks):
         return tracks
+    graph = tracks.graph_full
+    if tracks.segmentation is not None and graph.metadata.get("shape") is None:
+        # the new object needs to build its own segmentation view, assigning one via
+        # _segmentation binds the old one, and then the user cannot update it via painting
+        graph._update_metadata(shape=tuple(tracks.segmentation.shape))
     solution_tracks = SolutionTracks(
-        tracks.graph,
+        graph,
         scale=tracks.scale,
         ndim=tracks.ndim,
         features=tracks.features,
-        _segmentation=tracks.segmentation,
     )
     # Only needed on funtracks < 2.1, where passing a FeatureDict makes
     # __init__ activate the declared features without computing the missing

--- a/src/motile_tracker/motile/backend/motile_run.py
+++ b/src/motile_tracker/motile/backend/motile_run.py
@@ -239,7 +239,7 @@ class MotileRun(SolutionTracks):
             time_attr = tracks.features.time_key
         gaps = cls._load_list(run_dir=run_dir, filename=GAPS_FILENAME, required=False)
         return cls(
-            graph=tracks.graph,
+            graph=tracks.graph_full,
             run_name=run_name,
             solver_params=params,
             input_points=input_points,
@@ -250,7 +250,6 @@ class MotileRun(SolutionTracks):
             scale=scale,
             ndim=tracks.ndim,
             _features=tracks.features,
-            _segmentation=tracks.segmentation,
         )
 
     def _save_params(self, run_dir: Path):

--- a/tests/data_views/views_coordinator/test_tracks_list.py
+++ b/tests/data_views/views_coordinator/test_tracks_list.py
@@ -7,10 +7,12 @@ and the load_motile_run bug fix (must call MotileRun.load, not Tracks.load).
 import warnings
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 from funtracks.data_model import SolutionTracks, Tracks
 from funtracks.import_export import write_to_geff
 from qtpy.QtWidgets import QDialog
+from tracksdata.nodes import Mask
 
 from motile_tracker.data_views.views_coordinator.tracks_list import (
     TracksButton,
@@ -145,6 +147,36 @@ class TestTracksListAddRemove:
         converted = emitted[0][0]
         assert converted.features.tracklet_key in converted.graph.node_attr_keys()
         assert converted.features.lineage_key in converted.graph.node_attr_keys()
+
+    def test_view_tracks_segmentation_follows_edits(self, tracks_list, graph_2d):
+        """The emitted tracks must own their segmentation, not borrow the old one.
+
+        A GraphArrayView renders from, and listens to, the single graph object
+        it was built with. Handing the original view to the converted tracks
+        left it bound to the graph of the tracks in the list, so an edit made
+        through the converted tracks (painting a label) never invalidated its
+        cache: the pixels snapped back while the centroid moved.
+        """
+        plain_tracks = Tracks(graph_2d, ndim=3, time_attr="t", tracklet_attr="track_id")
+        assert plain_tracks.segmentation is not None
+
+        emitted = []
+        tracks_list.view_tracks.connect(lambda t, n: emitted.append((t, n)))
+        tracks_list.add_tracks(plain_tracks, "plain", select=True)
+        converted = emitted[0][0]
+
+        assert converted.segmentation.graph is converted.graph_solution
+
+        node = 1
+        time = converted.get_time(node)
+        assert (np.asarray(converted.segmentation[time]) == node).any()
+
+        old_mask = converted.get_mask(node)
+        converted.update_mask(
+            node, Mask(np.zeros_like(old_mask.mask), bbox=old_mask.bbox)
+        )
+
+        assert not (np.asarray(converted.segmentation[time]) == node).any()
 
     def test_view_tracks_passes_through_motile_run(self, tracks_list, motile_run):
         """A MotileRun is already a SolutionTracks, so it must be emitted


### PR DESCRIPTION
It is currently not possible to paint on the seg layer of a loaded geff or MotileRun. When you paint, the paint event appears to be immediately reverted, although the change is registered because the centroid point shifts. 
The problem is that `SolutionTracks(tracks.graph, ..., _segmentation=tracks.segmentation)` creates a new `graph_solution` but keeps the `GraphArrayView` bound to the old one. 

A quick fix is to rebuild the segmentation from the graph, instead of passing the old one, but it might be better to add a function on Funtracks to rebind a passed `_segmentation` to the current GraphArrayView?

Closes #480 