### PR TITLE
Add button for set/break division action

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2.1.0-a3,<3",
+    "funtracks @ git+https://github.com/funkelab/funtracks.git@refs/pull/278/head",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2.1.0-a3,<3",
+    "funtracks @ git+https://github.com/funkelab/funtracks.git@refs/pull/278/head"",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,15 +105,6 @@ dev = [
 ]
 # For gurobi, install separately: uv pip install "gurobipy>=12,<13"
 
-[tool.uv.sources]
-# Unreleased funtracks, for tracksdata >= 0.1.0rc9: that release swapped spatial-graph
-# for rstar-python. spatial-graph's prebuilt rtree is a Cython limited-API build that
-# collides with pygfx's uharfbuzz over the shared _cython_3_3_0limitednofinalize module
-# ("Shared Cython type cython_function_or_method has the wrong size"), which broke GEFF
-# import in the tree view. rstar-python is Rust, so there is nothing to collide with.
-# Drop this source once a funtracks release includes the commit.
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "d9d83ea23c273e880b5b82cdc8343235d8e9e9eb" }
-
 [tool.uv]
 # gurobi12 and gurobi13 conflict with each other (mutually exclusive version pins)
 conflicts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks @ git+https://github.com/funkelab/funtracks.git@refs/pull/278/head",
+    "funtracks>=2.1.0,<3",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",

--- a/src/motile_tracker/application_menus/editing_selection_menu.py
+++ b/src/motile_tracker/application_menus/editing_selection_menu.py
@@ -184,7 +184,7 @@ class EditingMenu(QWidget):
         node_box.setLayout(node_box_layout)
 
         edge_box = QGroupBox("Edit Edge(s)")
-        edge_box.setMaximumHeight(120)
+        edge_box.setMaximumHeight(170)
         edge_box_layout = QVBoxLayout()
 
         self.delete_edge_btn = QPushButton("Break [B]")
@@ -193,16 +193,24 @@ class EditingMenu(QWidget):
         self.create_edge_btn = QPushButton("Add [A]")
         self.create_edge_btn.clicked.connect(self.tracks_viewer.create_edge)
         self.create_edge_btn.setEnabled(False)
+        self.set_division_btn = QPushButton("Make/break division [Y]")
+        self.set_division_btn.setToolTip(
+            "Select a parent node and its two child nodes to connect them as a "
+            "division, or to break an existing division."
+        )
+        self.set_division_btn.clicked.connect(self.tracks_viewer.set_division)
+        self.set_division_btn.setEnabled(False)
 
         edge_box_layout.addWidget(self.delete_edge_btn)
         edge_box_layout.addWidget(self.create_edge_btn)
+        edge_box_layout.addWidget(self.set_division_btn)
 
         edge_box.setLayout(edge_box_layout)
 
-        self.undo_btn = QPushButton("Undo (Z)")
+        self.undo_btn = QPushButton("Undo [Z]")
         self.undo_btn.clicked.connect(self.tracks_viewer.undo)
 
-        self.redo_btn = QPushButton("Redo (R)")
+        self.redo_btn = QPushButton("Redo [R]")
         self.redo_btn.clicked.connect(self.tracks_viewer.redo)
 
         box_layout.addWidget(node_box)
@@ -215,7 +223,7 @@ class EditingMenu(QWidget):
         main_layout = QVBoxLayout()
         main_layout.addWidget(box)
         self.setLayout(main_layout)
-        self.setMaximumHeight(450)
+        self.setMaximumHeight(500)
 
     def update_track_id_color(self):
         """Display track ID value and color"""
@@ -236,6 +244,8 @@ class EditingMenu(QWidget):
         """Set the buttons to enabled/disabled depending on the selected nodes"""
 
         n_selected = len(self.tracks_viewer.selected_nodes)
+        self.set_division_btn.setEnabled(n_selected == 3)
+
         if n_selected == 0:
             self.delete_node_btn.setEnabled(False)
             self.delete_edge_btn.setEnabled(False)
@@ -268,4 +278,4 @@ class EditingSelectionWidget(QWidget):
         selection_editing_layout.addWidget(selection_widget)
         selection_editing_layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(selection_editing_layout)
-        self.setMaximumHeight(600)
+        self.setMaximumHeight(650)

--- a/src/motile_tracker/application_menus/editing_selection_menu.py
+++ b/src/motile_tracker/application_menus/editing_selection_menu.py
@@ -193,7 +193,7 @@ class EditingMenu(QWidget):
         self.create_edge_btn = QPushButton("Add [A]")
         self.create_edge_btn.clicked.connect(self.tracks_viewer.create_edge)
         self.create_edge_btn.setEnabled(False)
-        self.set_division_btn = QPushButton("Make/break division [Y]")
+        self.set_division_btn = QPushButton("Set/break division [Y]")
         self.set_division_btn.setToolTip(
             "Select a parent node and its two child nodes to connect them as a "
             "division, or to break an existing division."

--- a/src/motile_tracker/data_views/keybindings_config.py
+++ b/src/motile_tracker/data_views/keybindings_config.py
@@ -58,6 +58,11 @@ KEYBINDINGS = {
         "qt_keys": [Qt.Key_B],
         "targets": ["tracks_viewer"],
     },
+    "set_division": {
+        "napari_keys": ["y"],
+        "qt_keys": [Qt.Key_Y],
+        "targets": ["tracks_viewer"],
+    },
     "swap_nodes": {
         "napari_keys": ["s"],
         "qt_keys": [Qt.Key_S],

--- a/src/motile_tracker/data_views/views/tree_view/tree_plot_fpl.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_plot_fpl.py
@@ -131,6 +131,7 @@ class TreePlot(QWidget):
         self.setFocusPolicy(Qt.StrongFocus)
 
         self._closed = False  # set by close_figure(); the canvas is gone after that
+        self._scrolled = False  # set by the wheel handler, read via `scrolled`
         self.view_direction = "vertical"
         self.plot_type = "tree"
         self.feature = None
@@ -255,18 +256,39 @@ class TreePlot(QWidget):
         )
         self._subplot.add_animations(*self._animations)
 
-        # canvas mouse handling: right-click reset + shift-drag box-select
-        self._pointer_handlers = (
+        # canvas mouse handling: right-click reset + shift-drag box-select, plus
+        # scroll bookkeeping so a zoom modifier key can be told apart from a plain
+        # keyboard shortcut (see `scrolled`)
+        self._canvas_handlers = (
             (self._on_canvas_pointer_down, "pointer_down"),
             (self._on_canvas_pointer_move, "pointer_move"),
             (self._on_canvas_pointer_up, "pointer_up"),
+            (self._on_canvas_wheel, "wheel"),
         )
-        for handler, event_type in self._pointer_handlers:
+        for handler, event_type in self._canvas_handlers:
             self._figure.renderer.add_event_handler(handler, event_type)
 
     # ------------------------------------------------------------------ #
     # pan/zoom + X/Y axis lock
     # ------------------------------------------------------------------ #
+    @property
+    def scrolled(self) -> bool:
+        """Whether the user scrolled since the last `reset_scrolled` call.
+
+        X and Y double as zoom modifiers (held down while scrolling) and as plain
+        keyboard shortcuts, so TreeWidget resets this when such a key goes down and
+        checks it when the key comes back up.
+        """
+        return self._scrolled
+
+    def reset_scrolled(self) -> None:
+        """Forget any scrolling seen so far."""
+        self._scrolled = False
+
+    def _on_canvas_wheel(self, ev) -> None:
+        """Record that the user scrolled over the canvas."""
+        self._scrolled = True
+
     def setMouseEnabled(self, x: bool, y: bool) -> None:  # noqa: N802 (Qt-style name)
         """Restrict zoom/pan to the given axes (X or Y key held). Reconfigures the
         subplot's own PanZoomController so it stays correctly event-registered."""
@@ -296,7 +318,7 @@ class TreePlot(QWidget):
         for animation in self._animations:
             with contextlib.suppress(Exception):
                 self._subplot.remove_animation(animation)
-        for handler, event_type in self._pointer_handlers:
+        for handler, event_type in self._canvas_handlers:
             with contextlib.suppress(Exception):
                 self._figure.renderer.remove_event_handler(handler, event_type)
         with contextlib.suppress(Exception):

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -634,6 +634,10 @@ class TreeWidget(QWidget):
         """Swap the nodes by swapping upstream edges"""
         self.tracks_viewer.swap_nodes()
 
+    def set_division(self):
+        """Make or break a division between the three selected nodes"""
+        self.tracks_viewer.set_division()
+
     def undo(self):
         """Undo action."""
         self.tracks_viewer.undo()

--- a/src/motile_tracker/data_views/views/tree_view/tree_widget.py
+++ b/src/motile_tracker/data_views/views/tree_view/tree_widget.py
@@ -5,7 +5,7 @@ import contextlib
 import napari
 import numpy as np
 import pandas as pd
-from qtpy.QtCore import QEvent, QObject, Qt
+from qtpy.QtCore import QEvent, QObject
 from qtpy.QtGui import QKeyEvent
 from qtpy.QtWidgets import (
     QHBoxLayout,
@@ -185,8 +185,8 @@ class TreeWidget(QWidget):
 
         Priority order:
         1. Tree-widget-specific keybinds (highest priority) - call TreeWidget methods
-        2. General keybinds (work in table widget too) - call tracks_viewer methods
-        3. Modifier keybinds (mouse zoom constraints)
+        2. Modifier keybinds (mouse zoom constraints)
+        3. General keybinds (work in table widget too) - call tracks_viewer methods
         4. Navigation (arrow keys)
         """
         # Handle tree-widget-specific keybinds first (higher priority)
@@ -198,6 +198,18 @@ class TreeWidget(QWidget):
                 event.accept()
                 return
 
+        # Handle mouse zoom constraints (X/Y axes) before the general keybinds because a
+        # zoom modifier can double as a general keybind. The constraint applies while the
+        # key is held, and the general action only fires on release, if the user did
+        # not scroll in the meantime (see keyReleaseEvent).
+        if event.key() in TREE_WIDGET_MODIFIER_ACTIONS:
+            if not event.isAutoRepeat():
+                x_enabled, y_enabled = TREE_WIDGET_MODIFIER_ACTIONS[event.key()]
+                self.set_mouse_enabled(x=x_enabled, y=y_enabled)
+                self.tree_widget.reset_scrolled()
+            event.accept()
+            return
+
         # Try general keybinds (these also work in table widget)
         action_name = GENERAL_KEY_ACTIONS.get(event.key())
         if action_name:
@@ -206,13 +218,6 @@ class TreeWidget(QWidget):
                 method()
                 event.accept()
                 return
-
-        # Handle mouse zoom constraints (X/Y axes)
-        if event.key() in TREE_WIDGET_MODIFIER_ACTIONS:
-            x_enabled, y_enabled = TREE_WIDGET_MODIFIER_ACTIONS[event.key()]
-            self.set_mouse_enabled(x=x_enabled, y=y_enabled)
-            event.accept()
-            return
 
         # Handle navigation (Arrow keys)
         direction = TREE_WIDGET_NAVIGATION_KEYS.get(event.key())
@@ -288,10 +293,27 @@ class TreeWidget(QWidget):
         self.tree_widget.setMouseEnabled(x=x, y=y)
 
     def keyReleaseEvent(self, ev):
-        """Reset the mouse scrolling when releasing the X/Y key"""
+        """Reset the mouse scrolling when releasing a zoom modifier (X/Y) key.
 
-        if ev.key() == Qt.Key_X or ev.key() == Qt.Key_Y:
-            self.tree_widget.setMouseEnabled(x=True, y=True)
+        A zoom modifier that is also a general keybind (Y, which sets a division) was
+        only meant as a zoom modifier if the user scrolled while holding it down; a
+        plain tap runs the general action instead.
+        """
+
+        if ev.key() not in TREE_WIDGET_MODIFIER_ACTIONS or ev.isAutoRepeat():
+            return
+
+        scrolled = self.tree_widget.scrolled
+        self.tree_widget.setMouseEnabled(x=True, y=True)
+        self.tree_widget.reset_scrolled()
+        if scrolled:
+            return
+
+        action_name = GENERAL_KEY_ACTIONS.get(ev.key())
+        if action_name:
+            method = getattr(self.tracks_viewer, action_name, None)
+            if method:
+                method()
 
     def _update_selected(self):
         """Called whenever the selection list is updated. Only re-computes

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -11,6 +11,7 @@ from funtracks.user_actions import (
     UserAddEdge,
     UserDeleteEdge,
     UserDeleteNodes,
+    UserSetDivision,
     UserSwapPredecessors,
 )
 from psygnal import Signal
@@ -471,6 +472,19 @@ class TracksViewer:
             node2 = self.selected_nodes[1]
 
             UserSwapPredecessors(self.tracks, nodes=(int(node1), int(node2)))
+
+    def set_division(self, event=None):
+        """Calls the UserAction to make or break a division between the three
+        currently selected nodes
+        """
+
+        if self.tracks is None:
+            return
+        nodes = [int(node) for node in self.selected_nodes.as_list]
+        try:
+            UserSetDivision(self.tracks, tuple(nodes))
+        except InvalidActionError as e:
+            QMessageBox.warning(None, "Cannot set division", str(e))
 
     def create_edge(self, event=None):
         """Add an edge between the two currently selected nodes"""

--- a/tests/application_menus/test_editing_menu.py
+++ b/tests/application_menus/test_editing_menu.py
@@ -24,6 +24,7 @@ def test_button_states(make_napari_viewer, solution_tracks_2d, click_node):
     assert not editing_menu.swap_nodes_btn.isEnabled()
     assert not editing_menu.delete_edge_btn.isEnabled()
     assert not editing_menu.create_edge_btn.isEnabled()
+    assert not editing_menu.set_division_btn.isEnabled()
 
     # Test 2: Verify update_buttons() disables all buttons when selection is cleared
     # First select nodes to enable buttons
@@ -41,6 +42,7 @@ def test_button_states(make_napari_viewer, solution_tracks_2d, click_node):
     assert not editing_menu.swap_nodes_btn.isEnabled()
     assert not editing_menu.delete_edge_btn.isEnabled()
     assert not editing_menu.create_edge_btn.isEnabled()
+    assert not editing_menu.set_division_btn.isEnabled()
 
     # Test 3: Verify only delete button enabled with single node selection
     click_node(tracks_viewer, 1)
@@ -50,6 +52,7 @@ def test_button_states(make_napari_viewer, solution_tracks_2d, click_node):
     assert editing_menu.delete_node_btn.isEnabled()
     assert not editing_menu.delete_edge_btn.isEnabled()
     assert not editing_menu.create_edge_btn.isEnabled()
+    assert not editing_menu.set_division_btn.isEnabled()
 
     # Test 4: Verify all buttons enabled when two nodes selected
     click_node(tracks_viewer, 1)
@@ -61,17 +64,24 @@ def test_button_states(make_napari_viewer, solution_tracks_2d, click_node):
     assert editing_menu.swap_nodes_btn.isEnabled()
     assert editing_menu.delete_edge_btn.isEnabled()
     assert editing_menu.create_edge_btn.isEnabled()
+    assert not editing_menu.set_division_btn.isEnabled()
 
-    # Test 5: Verify only delete button enabled with 3+ nodes selected
+    # Test 5: Verify delete and division buttons enabled with 3 nodes selected
     click_node(tracks_viewer, 1)
     click_node(tracks_viewer, 2, append=True)
     click_node(tracks_viewer, 3, append=True)
     editing_menu.update_buttons()
 
-    # Verify only delete is enabled, others disabled
+    # Verify only delete and division are enabled, others disabled
     assert editing_menu.delete_node_btn.isEnabled()
+    assert editing_menu.set_division_btn.isEnabled()
     assert not editing_menu.delete_edge_btn.isEnabled()
     assert not editing_menu.create_edge_btn.isEnabled()
+
+    # Test 6: Verify division button is disabled again with 4 nodes selected
+    click_node(tracks_viewer, 4, append=True)
+    editing_menu.update_buttons()
+    assert not editing_menu.set_division_btn.isEnabled()
 
 
 def test_button_interactions(make_napari_viewer, solution_tracks_2d, qtbot, click_node):
@@ -89,6 +99,8 @@ def test_button_interactions(make_napari_viewer, solution_tracks_2d, qtbot, clic
     tracks_viewer.swap_nodes = swap_mock
     delete_edge_mock = MagicMock()
     tracks_viewer.delete_edge = delete_edge_mock
+    set_division_mock = MagicMock()
+    tracks_viewer.set_division = set_division_mock
     new_track_mock = MagicMock()
     tracks_viewer.request_new_track = new_track_mock
     undo_mock = MagicMock()
@@ -119,15 +131,21 @@ def test_button_interactions(make_napari_viewer, solution_tracks_2d, qtbot, clic
     qtbot.mouseClick(editing_menu.delete_edge_btn, Qt.MouseButton.LeftButton)
     delete_edge_mock.assert_called_once()
 
-    # Test 5: Start New Track button calls tracks_viewer.request_new_track()
+    # Test 5: Make/break division button calls tracks_viewer.set_division()
+    click_node(tracks_viewer, 3, append=True)
+    editing_menu.update_buttons()
+    qtbot.mouseClick(editing_menu.set_division_btn, Qt.MouseButton.LeftButton)
+    set_division_mock.assert_called_once()
+
+    # Test 6: Start New Track button calls tracks_viewer.request_new_track()
     qtbot.mouseClick(editing_menu.new_track_btn, Qt.MouseButton.LeftButton)
     new_track_mock.assert_called_once()
 
-    # Test 6: Undo button calls tracks_viewer.undo()
+    # Test 7: Undo button calls tracks_viewer.undo()
     qtbot.mouseClick(editing_menu.undo_btn, Qt.MouseButton.LeftButton)
     undo_mock.assert_called_once()
 
-    # Test 7: Redo button calls tracks_viewer.redo()
+    # Test 8: Redo button calls tracks_viewer.redo()
     qtbot.mouseClick(editing_menu.redo_btn, Qt.MouseButton.LeftButton)
     redo_mock.assert_called_once()
 

--- a/tests/data_views/views/tree_view/test_tree_widget.py
+++ b/tests/data_views/views/tree_view/test_tree_widget.py
@@ -246,6 +246,8 @@ def test_keyboard_shortcuts_all(mock_move, viewer, solution_tracks_2d, qtbot):
     tracks_viewer.delete_edge = delete_edge_mock
     swap_mock = MagicMock()
     tracks_viewer.swap_nodes = swap_mock
+    set_division_mock = MagicMock()
+    tracks_viewer.set_division = set_division_mock
     undo_mock = MagicMock()
     tracks_viewer.undo = undo_mock
     redo_mock = MagicMock()
@@ -286,9 +288,12 @@ def test_keyboard_shortcuts_all(mock_move, viewer, solution_tracks_2d, qtbot):
     qtbot.keyPress(tree_widget, Qt.Key_X)
     qtbot.keyRelease(tree_widget, Qt.Key_X)
 
-    # Test 9: Y key release re-enables mouse in both directions
+    # Test 9: Y is a zoom modifier while held; tapping it (no scrolling in between)
+    # calls set_division on release, and re-enables the mouse in both directions
     qtbot.keyPress(tree_widget, Qt.Key_Y)
+    set_division_mock.assert_not_called()
     qtbot.keyRelease(tree_widget, Qt.Key_Y)
+    set_division_mock.assert_called_once()
 
     # Test 10: All arrow keys call navigation widget move method
     qtbot.keyPress(tree_widget, Qt.Key_Left)
@@ -329,6 +334,35 @@ def test_keyboard_shortcuts_all(mock_move, viewer, solution_tracks_2d, qtbot):
     tracks_viewer.restore_selection = restore_mock
     qtbot.keyPress(tree_widget, Qt.Key_E)
     restore_mock.assert_called_once()
+
+
+def test_scrolling_while_holding_y_zooms_instead_of_setting_a_division(
+    viewer, solution_tracks_2d, qtbot
+):
+    """Test that Y only sets a division when it is not used as a zoom modifier.
+
+    Y restricts the zoom to the y-axis while it is held down, so scrolling with Y
+    down must not also make/break a division when the key is released.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_2d, name="test")
+    set_division_mock = MagicMock()
+    tracks_viewer.set_division = set_division_mock
+
+    tree_widget = TreeWidget(viewer)
+
+    qtbot.keyPress(tree_widget, Qt.Key_Y)
+    # scrolling over the canvas is what pygfx reports to the plot as a wheel event
+    tree_widget.tree_widget._on_canvas_wheel(None)
+    assert tree_widget.tree_widget.scrolled
+    qtbot.keyRelease(tree_widget, Qt.Key_Y)
+
+    set_division_mock.assert_not_called()
+    # the scroll is forgotten again, so the next tap does set a division
+    assert not tree_widget.tree_widget.scrolled
+    qtbot.keyPress(tree_widget, Qt.Key_Y)
+    qtbot.keyRelease(tree_widget, Qt.Key_Y)
+    set_division_mock.assert_called_once()
 
 
 def test_mode_and_plot_type_switching(viewer, solution_tracks_2d, click_node):

--- a/tests/data_views/views_coordinator/test_tracks_viewer.py
+++ b/tests/data_views/views_coordinator/test_tracks_viewer.py
@@ -195,6 +195,55 @@ class TestEdgeOperations:
         # Conflicting edge should have been removed by force
         assert not tracks.graph.has_edge(3, 4)
 
+    def test_set_division_makes_and_breaks_division(self, viewer, graph_2d, click_node):
+        """Test set_division connects a mother to two daughters and back again.
+
+        Node 4 (t2) already has daughter 5 (t4), node 6 (t4) is unconnected, so the
+        first call completes the division and the second call breaks it.
+        """
+        tracks = MotileRun(graph=graph_2d, run_name="test", ndim=3, time_attr="t")
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+
+        click_node(tracks_viewer, 5)
+        click_node(tracks_viewer, 6, append=True)
+        click_node(tracks_viewer, 4, append=True)
+
+        tracks_viewer.set_division()
+        assert tracks.graph.has_edge(4, 5)
+        assert tracks.graph.has_edge(4, 6)
+
+        # Running it again on the same trio breaks the division
+        tracks_viewer.set_division()
+        assert not tracks.graph.has_edge(4, 5)
+        assert not tracks.graph.has_edge(4, 6)
+
+        # Undo restores the division
+        tracks_viewer.undo()
+        assert tracks.graph.has_edge(4, 5)
+        assert tracks.graph.has_edge(4, 6)
+
+    def test_set_division_invalid_selection_warns(self, viewer, graph_2d, click_node):
+        """Test set_division shows a warning instead of raising on a bad selection."""
+        tracks = MotileRun(graph=graph_2d, run_name="test", ndim=3, time_attr="t")
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+
+        # Nodes 2 and 3 are both at t=1, so there is no unique mother node
+        click_node(tracks_viewer, 2)
+        click_node(tracks_viewer, 3, append=True)
+        click_node(tracks_viewer, 5, append=True)
+
+        with patch(
+            "motile_tracker.data_views.views_coordinator.tracks_viewer.QMessageBox.warning"
+        ) as warning:
+            tracks_viewer.set_division()
+
+        warning.assert_called_once()
+        assert "exactly one node to be earlier" in warning.call_args[0][2]
+        assert not tracks.graph.has_edge(2, 5)
+        assert not tracks.graph.has_edge(3, 5)
+
 
 class TestDisplayModes:
     """Tests for display mode switching and filtering."""

--- a/tests/data_views/views_coordinator/test_tracks_viewer.py
+++ b/tests/data_views/views_coordinator/test_tracks_viewer.py
@@ -244,6 +244,27 @@ class TestEdgeOperations:
         assert not tracks.graph.has_edge(2, 5)
         assert not tracks.graph.has_edge(3, 5)
 
+    def test_set_division_without_three_nodes_warns(self, viewer, graph_2d, click_node):
+        """Test set_division warns instead of raising when not exactly 3 nodes are selected.
+
+        Unlike the button, the [Y] keybinding is active whatever the selection is, so
+        set_division must cope with a selection that is not a trio.
+        """
+        tracks = MotileRun(graph=graph_2d, run_name="test", ndim=3, time_attr="t")
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+
+        for select in (lambda: None, lambda: click_node(tracks_viewer, 4)):
+            tracks_viewer.selected_nodes.reset()
+            select()
+            with patch(
+                "motile_tracker.data_views.views_coordinator.tracks_viewer.QMessageBox.warning"
+            ) as warning:
+                tracks_viewer.set_division()
+
+            warning.assert_called_once()
+            assert "exactly 3 distinct nodes" in warning.call_args[0][2]
+
 
 class TestDisplayModes:
     """Tests for display mode switching and filtering."""


### PR DESCRIPTION
Button to trigger a set/break division action between a trio of nodes. 

See https://github.com/funkelab/motile_tracker/issues/146

Needs Funtracks PR: https://github.com/funkelab/funtracks/pull/278