### PR TITLE
import/export SQL database

### DIFF
--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -139,6 +139,11 @@ column mapping step described in :doc:`Importing externally generated tracks <vi
 In short: save/load round-trips within the application, import/export crosses the
 boundary to other tools.
 
+There is a third option, described under :ref:`working-in-a-database` below, where
+the tracks live in a database on disk and every edit is written there as you make
+it. That removes the need to remember to save at all, at the cost of the tracks
+being tied to one file on one machine.
+
 Saving tracks
 -------------
 Above the results list are a ``Save directory`` field, with a ``Browse`` button, and a
@@ -171,6 +176,9 @@ button starts it:
   the ``Run Editor`` along with the tracks. Select the ``.geff`` store the run was
   saved to. Runs saved by older versions, which used a timestamped directory
   containing the tracks and a separate parameters file, can still be loaded.
+- ``SQL database`` - open a tracks database. Unlike the other options this
+  does not read the tracks into memory: the database is opened in place and every
+  edit is written to it. See :ref:`working-in-a-database`.
 - ``External tracks from CSV`` and ``External tracks from geff`` - import tracks that
   were generated elsewhere. These open the import dialog, where you map columns to
   attributes and optionally provide a segmentation; see
@@ -179,10 +187,63 @@ button starts it:
 Exporting tracks
 ----------------
 The export button beside a set of tracks in the results list opens the export dialog,
-where you choose ``GEFF``
-or ``CSV`` and pick the location, optionally including the (relabeled) segmentation as
+where you choose ``GEFF``, ``CSV`` or ``SQL database`` and pick the location, optionally
+including the (relabeled) segmentation as
 zarr or tiff. You can also export a subset of tracks from the Groups tab. Exported tracks are meant to be read by other tools: to continue working
-on them here later, save them instead.
+on them here later, save them instead, or export a database and keep editing in it.
+
+.. _working-in-a-database:
+
+Working in a database
+---------------------
+Tracks normally live in memory until you save them. They can instead live in a SQLite
+database on disk, where every edit is written as you make it. This is worth doing when:
+
+- you do not want to lose work if napari closes unexpectedly, since there is nothing
+  to remember to save;
+- the graph is large, because the candidate nodes the solver considered but did not
+  select stay on disk rather than in memory;
+- several people annotate the same tracks, for example by each taking a different
+  range of timepoints.
+
+Getting into a database
+~~~~~~~~~~~~~~~~~~~~~~~
+Importing never puts tracks in a database - CSV and geff imports always build an
+in-memory copy. There are two ways in:
+
+- **Export one.** In the export dialog choose ``SQL database``. By default the current
+  tracks switch over to the file you just wrote, so editing continues there - which is
+  usually why you are writing one. Switching over clears the undo history. Tick
+  ``Continue editing the in-memory graph`` if you would rather write a plain copy and
+  carry on as before.
+- **Open one.** Choose ``SQL database`` in the load dropdown and select the
+  ``.db`` file.
+
+Exporting a copy of tracks that are *already* in a database works the other way round:
+the default is to stay in the database you are in, since a copy is normally something
+you are handing to someone else. Untick the box to move over to the copy instead.
+
+When a set of tracks in the results list is stored in a database, the path is shown
+above the list.
+
+What a database holds
+~~~~~~~~~~~~~~~~~~~~~
+A database holds the whole graph, including the segmentation and the candidate nodes
+that the solver considered but did not select - which a geff export drops. Deleted
+nodes are kept as candidates too, so a reopened database still knows about them and
+they can be reconnected. Undo history is not part of the graph and is not kept: after
+reopening, the undo stack starts empty, just as it does after loading a geff.
+
+A database also records which attributes hold time, position and track ids, and the
+scale if the tracks had one, so it reopens without asking you anything. A database
+written by another tool will not have that; the attributes are then guessed from the
+column names, and the tracks open without a scale, just as they do when loading a geff.
+
+Saving and databases
+~~~~~~~~~~~~~~~~~~~~
+The save button still writes a geff, for every set of tracks including database-backed
+ones. For those, saving is not what protects your work - the database already does
+that - it is how you take a snapshot or hand the tracks to someone else.
 
 .. _Issue #48: https://github.com/funkelab/motile_tracker/issues/48
 .. _Cell Tracking Challenge: https://celltrackingchallenge.net/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,16 @@ dev = [
 ]
 # For gurobi, install separately: uv pip install "gurobipy>=12,<13"
 
+# TEMPORARY: pin funtracks to the `sql` branch (funkelab/funtracks#270), which adds
+# SQL-backend support to the tracksdata graph helpers and carries the two edit-path
+# fixes a SQL-backed Tracks needs (time key excluded from revive_attrs, feature
+# attr-key registration on graph_full). That PR in turn pins tracksdata to the
+# `graph-views` branch (royerlab/tracksdata#325), whose root-to-view attribute
+# propagation is required or a SQL-backed segmentation renders stale after every edit.
+# Replace with a released version pin once both land.
+[tool.uv.sources]
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "149b9d71c517f83b799bc2acfc95694973be1b33" }
+
 [tool.uv]
 # gurobi12 and gurobi13 conflict with each other (mutually exclusive version pins)
 conflicts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,14 @@ dependencies =[
     # Drop it once Cython encodes the limited-API level in that module name, or once
     # the two agree on a level.
     "blosc2>=4.11,<4.12",
+    # Not used directly (it arrives via napari). 0.16.0 iterates a snapshot of the
+    # slot list (`for caller in list(self._slots)`, pyapp-kit/psygnal#413), so a weak
+    # callback whose referent is collected *during* an emit is still called and raises
+    # ReferenceError instead of being skipped. napari's TransformChain hits this: each
+    # child transform's `changed` holds a weak ref to the chain, and the ortho views
+    # drop a chain from inside a `changed` callback. Drop the pin once psygnal skips
+    # dead callbacks again.
+    "psygnal<0.16",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ dev = [
 # propagation is required or a SQL-backed segmentation renders stale after every edit.
 # Replace with a released version pin once both land.
 [tool.uv.sources]
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "149b9d71c517f83b799bc2acfc95694973be1b33" }
+funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "1de541258646c32340178c4e01c211c10762033f" }
 
 [tool.uv]
 # gurobi12 and gurobi13 conflict with each other (mutually exclusive version pins)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,11 @@ dependencies =[
     # child transform's `changed` holds a weak ref to the chain, and the ortho views
     # drop a chain from inside a `changed` callback. Drop the pin once psygnal skips
     # dead callbacks again.
-    "psygnal<0.16",
+    # The floor is not incidental: naming psygnal here makes it a *direct*
+    # dependency, so the lowest-direct CI job resolves it to the floor instead of
+    # to the newest release, and 0.14.0 fails ~90 tests with "no signature found
+    # for builtin emit of SignalInstance".
+    "psygnal>=0.15.1,<0.16",
 ]
 
 [project.optional-dependencies]

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -299,7 +299,13 @@ class TrackLabels(ContourLabels):
             target_value = 0
         else:
             self._ensure_valid_label()
-            target_value = self.selected_label
+            # TODO: drop this conversion once tracksdata coerces numpy scalars at
+            # the SQL query boundary; see the note in _ensure_valid_label. Passing
+            # napari's numpy selected_label straight through makes
+            # UserUpdateSegmentation read an existing node as missing on a
+            # database-backed graph, and it then tries to add a node that is
+            # already there.
+            target_value = int(self.selected_label)
 
         with self.events.selected_label.blocker():
             try:
@@ -425,13 +431,21 @@ class TrackLabels(ContourLabels):
         update_colormap = False
         if self.tracks_viewer.tracks is not None:
             current_timepoint = self.viewer.dims.current_step[0]
+            # TODO: drop this conversion once tracksdata coerces numpy scalars at
+            # the SQL query boundary. napari stores selected_label as a numpy
+            # integer, and SQLGraph.has_node(np.int64(n)) answers False where
+            # has_node(n) answers True, so an existing node reads as missing and
+            # the caller goes on to add a node that is already there. The
+            # in-memory backend matches either type, so this only bites on a
+            # database. Same conversion in _on_paint.
+            selected_label = int(self.selected_label)
             # if a node with the given label is already in the graph
-            if self.tracks_viewer.tracks.graph.has_node(self.selected_label):
+            if self.tracks_viewer.tracks.graph.has_node(selected_label):
                 # Update the track id
                 self.tracks_viewer.selected_track = (
-                    self.tracks_viewer.tracks.get_track_id(self.selected_label)
+                    self.tracks_viewer.tracks.get_track_id(selected_label)
                 )
-                existing_time = self.tracks_viewer.tracks.get_time(self.selected_label)
+                existing_time = self.tracks_viewer.tracks.get_time(selected_label)
                 if existing_time == current_timepoint:
                     # we are changing the existing node. This is fine
                     pass

--- a/src/motile_tracker/data_views/views_coordinator/tracks_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_list.py
@@ -311,14 +311,19 @@ class TracksList(QGroupBox):
 
     def _selection_changed(self):
         selected = self.tracks_list.selectedItems()
+        # Updated even with nothing selected: removing the last database-backed
+        # row would otherwise leave the note up, still claiming edits are being
+        # written to a database that is no longer open.
+        self._update_on_disk_label(
+            self.tracks_list.itemWidget(selected[0]).tracks if selected else None
+        )
         if selected:
             tracks_button = self.tracks_list.itemWidget(selected[0])
             name = tracks_button.name.text()
             self._update_save_name(name)
-            self._update_on_disk_label(tracks_button.tracks)
             self.view_tracks.emit(_as_solution_tracks(tracks_button.tracks), name)
 
-    def _update_on_disk_label(self, tracks: Tracks) -> None:
+    def _update_on_disk_label(self, tracks: Tracks | None) -> None:
         """Say so when the selected tracks are already stored in a database.
 
         Saving still writes a geff for every backend, so without this the save
@@ -326,9 +331,14 @@ class TracksList(QGroupBox):
         which for a database-backed session is not true.
 
         Args:
-            tracks (Tracks): The tracks now selected.
+            tracks (Tracks | None): The tracks now selected, or None if the
+                selection was cleared.
         """
-        database = sql_database_path(tracks) if is_sql_backed(tracks) else None
+        database = (
+            sql_database_path(tracks)
+            if tracks is not None and is_sql_backed(tracks)
+            else None
+        )
         if database is None:
             self.on_disk_label.setVisible(False)
             return

--- a/src/motile_tracker/data_views/views_coordinator/tracks_list.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_list.py
@@ -34,9 +34,17 @@ from motile_tracker.import_export.menus.export_dialog import ExportDialog
 from motile_tracker.import_export.menus.import_dialog import (
     ImportDialog,
 )
+from motile_tracker.import_export.sql_io import (
+    SQL_SUFFIX,
+    is_sql_backed,
+    sql_database_path,
+    tracks_from_sql,
+)
 from motile_tracker.motile.backend.motile_run import MotileRun
 
 GEFF_SUFFIX = ".geff"
+
+SQL_LOAD_OPTION = "SQL database"
 
 
 def default_save_dir() -> Path:
@@ -111,7 +119,7 @@ class TracksButton(QWidget):
         export_icon = qticon(FA6S.file_export, color="white")
         self.export = QPushButton(icon=export_icon)
         self.export.setFixedSize(20, 20)
-        self.export.setToolTip("Export tracks to CSV or geff")
+        self.export.setToolTip("Export tracks to CSV, geff or a SQL database")
         layout = QHBoxLayout()
         layout.setSpacing(10)
         layout.addWidget(self.name)
@@ -194,6 +202,12 @@ class TracksList(QGroupBox):
         save_name_row.addWidget(self.save_name_line)
         save_name_row.addWidget(QLabel(GEFF_SUFFIX))
 
+        # Shown only for tracks stored in a database, where the save fields above
+        # are about taking a geff snapshot rather than about not losing work.
+        self.on_disk_label = QLabel()
+        self.on_disk_label.setWordWrap(True)
+        self.on_disk_label.setVisible(False)
+
         self.tracks_list = QListWidget()
         self.tracks_list.setSelectionMode(
             QAbstractItemView.SelectionMode.SingleSelection
@@ -205,6 +219,7 @@ class TracksList(QGroupBox):
         self.dropdown_menu.addItems(
             [
                 "Tracks (geff)",
+                SQL_LOAD_OPTION,
                 "Motile Run",
                 "External tracks from CSV",
                 "External tracks from geff",
@@ -221,6 +236,7 @@ class TracksList(QGroupBox):
         layout.addLayout(save_dir_header)
         layout.addWidget(self.save_dir_line)
         layout.addLayout(save_name_row)
+        layout.addWidget(self.on_disk_label)
         layout.addWidget(self.tracks_list)
         layout.addLayout(load_menu)
         self.setLayout(layout)
@@ -299,7 +315,28 @@ class TracksList(QGroupBox):
             tracks_button = self.tracks_list.itemWidget(selected[0])
             name = tracks_button.name.text()
             self._update_save_name(name)
+            self._update_on_disk_label(tracks_button.tracks)
             self.view_tracks.emit(_as_solution_tracks(tracks_button.tracks), name)
+
+    def _update_on_disk_label(self, tracks: Tracks) -> None:
+        """Say so when the selected tracks are already stored in a database.
+
+        Saving still writes a geff for every backend, so without this the save
+        fields read as the only thing standing between the user and lost work,
+        which for a database-backed session is not true.
+
+        Args:
+            tracks (Tracks): The tracks now selected.
+        """
+        database = sql_database_path(tracks) if is_sql_backed(tracks) else None
+        if database is None:
+            self.on_disk_label.setVisible(False)
+            return
+        self.on_disk_label.setText(
+            f"<i>Stored in <b>{database}</b> and saved there as you edit. "
+            f"Saving writes a separate geff snapshot.</i>"
+        )
+        self.on_disk_label.setVisible(True)
 
     def add_tracks(self, tracks: Tracks, name: str, select=True):
         """Add tracks to the list and optionally select them. Will make a new
@@ -328,10 +365,14 @@ class TracksList(QGroupBox):
             self.tracks_list.setCurrentRow(len(self.tracks_list) - 1)
 
     def show_export_dialog(self, item: QListWidgetItem) -> None:
-        """Prompt user to choose export format (csv or geff), then export the tracks
-        object from the list accordingly.
+        """Prompt user to choose export format (csv, geff or SQL database), then
+        export the tracks object from the list accordingly.
         You must pass the list item that represents the tracks, not the tracks object
         itself.
+
+        Exporting to a database can also switch the session over to it, in which
+        case the dialog hands back a new tracks object and the row is repointed
+        at it.
 
         Args:
             item (QListWidgetItem):  The list item containing the TracksButton that
@@ -344,9 +385,30 @@ class TracksList(QGroupBox):
         self.request_colormap.emit()
         colormap = self.colormap
 
-        ExportDialog.show_export_dialog(
+        result = ExportDialog.show_export_dialog(
             self, tracks=tracks, name=name, colormap=colormap
         )
+        if isinstance(result, Tracks):
+            self._replace_tracks(item, result)
+
+    def _replace_tracks(self, item: QListWidgetItem, tracks: Tracks) -> None:
+        """Point a row at a different tracks object and redisplay it.
+
+        Re-selecting is what makes the swap visible: it drives _selection_changed,
+        which re-emits view_tracks, which has TracksViewer rebuild the layers and
+        the tree against the new graph.
+
+        Args:
+            item (QListWidgetItem): The row to repoint.
+            tracks (Tracks): The tracks it should now hold.
+        """
+        widget: TracksButton = self.tracks_list.itemWidget(item)
+        widget.tracks = tracks
+        if self.tracks_list.currentItem() is item:
+            # Already selected, so setCurrentItem would not emit anything.
+            self._selection_changed()
+        else:
+            self.tracks_list.setCurrentItem(item)
 
     def save_tracks(self, item: QListWidgetItem):
         """Saves a tracks object from the list. You must pass the list item that
@@ -405,6 +467,8 @@ class TracksList(QGroupBox):
         selection = self.dropdown_menu.currentText()
         if selection == "Tracks (geff)":
             result = self.load_internal_tracks()
+        elif selection == SQL_LOAD_OPTION:
+            result = self.load_sql_tracks()
         elif selection == "Motile Run":
             result = self.load_motile_run()
         elif selection == "External tracks from CSV":
@@ -452,6 +516,35 @@ class TracksList(QGroupBox):
         store directly (the path written by :func:`write_to_geff`).
         """
         return self._load_from_dialog(import_from_geff)
+
+    def load_sql_tracks(self) -> tuple[Tracks, str, Path] | None:
+        """Open an existing tracks database.
+
+        The database is opened in place rather than read into memory, so from
+        here on every edit is written to that file as it is made. Cannot go
+        through _load_from_dialog, which asks for a directory: a database is a
+        single file.
+
+        A database that records no scale loads without one, exactly as loading a
+        geff does - tracks with no scale are an ordinary state throughout the
+        application, so this is not worth interrupting the load to ask about.
+        """
+        path_str, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open tracks database",
+            str(default_save_dir()),
+            f"SQLite database (*{SQL_SUFFIX});;All files (*)",
+        )
+        if not path_str:
+            return None
+        path = Path(path_str)
+
+        try:
+            tracks = tracks_from_sql(path)
+        except Exception as e:  # noqa: BLE001 - any driver error means "not loadable"
+            warn(f"Could not load tracks from {path}: {e}", stacklevel=2)
+            return None
+        return tracks, path.stem, path
 
     def load_motile_run(self) -> tuple[Tracks, str, Path] | None:
         """Load a MotileRun from disk. The user selects the directory created

--- a/src/motile_tracker/import_export/menus/export_dialog.py
+++ b/src/motile_tracker/import_export/menus/export_dialog.py
@@ -15,19 +15,63 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
 )
 
+from motile_tracker.import_export.sql_io import (
+    SQL_SUFFIX,
+    is_sql_backed,
+    rebind_tracks_to_graph,
+    sql_database_path,
+    write_tracks_to_sql,
+)
+
+SQL_EXPORT_TYPE = "SQL database"
+
 
 class ExportTypeDialog(QDialog):
-    def __init__(self, parent=None, label: str = "", has_segmentation: bool = False):
+    def __init__(
+        self,
+        parent=None,
+        label: str = "",
+        has_segmentation: bool = False,
+        offer_sql: bool = True,
+        already_on_disk: Path | None = None,
+    ):
+        """
+        Args:
+            parent: The parent widget.
+            label (str): Text shown above the format selector.
+            has_segmentation (bool): Whether the tracks carry a segmentation, and
+                so whether to offer exporting it as a standalone file.
+            offer_sql (bool): Whether to offer the SQL database format. False for
+                a group export, which writes a subset of nodes; a database is
+                written whole (including candidates) so the two do not compose.
+            already_on_disk (Path | None): The database the tracks already live
+                in, if they are SQL-backed. Shown as a note, because for those
+                tracks exporting is about sharing, not about not losing work.
+        """
         super().__init__(parent)
         self.setWindowTitle("Select Export Type")
+        # Several of the explanatory labels below wrap; without a width to wrap
+        # against the dialog opens narrow enough to squash them.
+        self.setMinimumWidth(450)
 
         layout = QVBoxLayout(self)
 
         if label:
             layout.addWidget(QLabel(label))
 
+        if already_on_disk is not None:
+            on_disk_label = QLabel(
+                f"<i>These tracks are stored in <b>{already_on_disk}</b> and are "
+                f"kept up to date there automatically. Exporting is only needed "
+                f"to hand the data to someone else.</i>"
+            )
+            on_disk_label.setWordWrap(True)
+            layout.addWidget(on_disk_label)
+
         self.export_type_combo = QComboBox()
         self.export_type_combo.addItems(["GEFF", "CSV"])
+        if offer_sql:
+            self.export_type_combo.addItem(SQL_EXPORT_TYPE)
         layout.addWidget(self.export_type_combo)
 
         self._geff_seg_label = QLabel(
@@ -38,6 +82,41 @@ class ExportTypeDialog(QDialog):
         self._geff_seg_label.setWordWrap(True)
         self._geff_seg_label.setVisible(False)
         layout.addWidget(self._geff_seg_label)
+
+        self._sql_label = QLabel(
+            "<i>A SQLite database holding the whole graph, including the "
+            "segmentation.</i>"
+        )
+        self._sql_label.setWordWrap(True)
+        self._sql_label.setVisible(False)
+        layout.addWidget(self._sql_label)
+
+        # The default always leaves you working in a database, never in memory.
+        # For in-memory tracks that means switching over to the one being
+        # written (unticked). For tracks already in a database it means staying
+        # in the one they are in (ticked), since exporting a copy is about
+        # handing it over, not about moving your session into it.
+        #
+        # The text is broken over two lines by hand: a QCheckBox label does not
+        # wrap, so on one line it gets cropped.
+        staying = "the current database" if already_on_disk else "the in-memory graph"
+        self.keep_in_memory_checkbox = QCheckBox(
+            f"Continue editing {staying}\n"
+            f"(otherwise switch to the newly saved database)"
+        )
+        self.keep_in_memory_checkbox.setChecked(already_on_disk is not None)
+        self.keep_in_memory_checkbox.setVisible(False)
+        layout.addWidget(self.keep_in_memory_checkbox)
+
+        # Stated in the dialog rather than only in a tooltip: clearing undo is
+        # the one thing about switching over that a user would not expect.
+        self._rebind_label = QLabel(
+            "<i>Switching over writes every later edit straight to the database, "
+            "so nothing is lost if napari closes. Undo history is cleared.</i>"
+        )
+        self._rebind_label.setWordWrap(True)
+        self._rebind_label.setVisible(False)
+        layout.addWidget(self._rebind_label)
 
         self.seg_checkbox = QCheckBox("Export segmentation")
         self.seg_checkbox.setVisible(has_segmentation)
@@ -65,8 +144,16 @@ class ExportTypeDialog(QDialog):
 
     def _on_export_type_changed(self, export_type: str) -> None:
         is_geff = export_type == "GEFF"
-        self.seg_checkbox.setVisible(self._has_segmentation)
+        is_sql = export_type == SQL_EXPORT_TYPE
+        # A database always holds the segmentation, and holds it as part of the
+        # graph, so there is nothing to tick and no format to choose.
+        self.seg_checkbox.setVisible(self._has_segmentation and not is_sql)
         self._geff_seg_label.setVisible(self._has_segmentation and is_geff)
+        self._sql_label.setVisible(is_sql)
+        self.keep_in_memory_checkbox.setVisible(is_sql)
+        self._rebind_label.setVisible(is_sql)
+        if is_sql:
+            self.seg_checkbox.setChecked(False)
 
     def _on_seg_toggled(self, checked: bool):
         for w in (self.seg_format_label, self.seg_format_combo, self.relabel_checkbox):
@@ -75,6 +162,15 @@ class ExportTypeDialog(QDialog):
     @property
     def export_type(self) -> str:
         return self.export_type_combo.currentText()
+
+    @property
+    def rebind(self) -> bool:
+        """Whether to switch the session over to the database being written.
+
+        The checkbox asks the opposite question - whether to stay in memory - so
+        that leaving it alone exports without changing anything.
+        """
+        return not self.keep_in_memory_checkbox.isChecked()
 
     @property
     def save_segmentation(self) -> bool:
@@ -90,7 +186,7 @@ class ExportTypeDialog(QDialog):
 
 
 class ExportDialog:
-    """Handles exporting tracks to CSV or geff."""
+    """Handles exporting tracks to CSV, geff or a SQL database."""
 
     @staticmethod
     def show_export_dialog(
@@ -100,14 +196,22 @@ class ExportDialog:
         colormap: napari.utils.Colormap,
         nodes_to_keep: set[int] | None = None,
     ):
-        """Export tracks to CSV or geff, with the option to export a subset of nodes only.
+        """Export tracks to CSV, geff or a SQL database, with the option to export
+        a subset of nodes only.
 
         Args:
             tracks (Tracks): to be exported Tracks object.
             name (str): filename for exporting
             nodes_to_keep (set[int], optional): list of nodes to be exported. Ancestor
                 nodes will automatically be included to make sure the graph has no
-                missing parent nodes.
+                missing parent nodes. Disables the SQL format, which writes the
+                whole graph.
+
+        Returns:
+            Tracks | bool: The tracks to carry on with when the user exported a
+                database and asked to keep editing in it, otherwise True on a
+                successful export and False if nothing was written. Truthy either
+                way, so callers that only check success keep working.
         """
         if nodes_to_keep is None:
             label = "Choose tracks export format:"
@@ -123,7 +227,13 @@ class ExportDialog:
             )
 
         dialog = ExportTypeDialog(
-            parent, label, has_segmentation=tracks.segmentation is not None
+            parent,
+            label,
+            has_segmentation=tracks.segmentation is not None,
+            offer_sql=nodes_to_keep is None,
+            already_on_disk=sql_database_path(tracks)
+            if is_sql_backed(tracks)
+            else None,
         )
 
         if dialog.exec_() != QDialog.Accepted:
@@ -133,6 +243,9 @@ class ExportDialog:
         save_segmentation = dialog.save_segmentation
         seg_file_format = dialog.seg_file_format
         seg_label_attr = dialog.seg_label_attr
+
+        if export_type == SQL_EXPORT_TYPE:
+            return ExportDialog._export_to_sql(parent, tracks, name, dialog.rebind)
 
         if export_type == "CSV":
             csv_dialog = QFileDialog(parent, "Save to CSV")
@@ -220,3 +333,48 @@ class ExportDialog:
             except ValueError as e:
                 QMessageBox.warning(parent, "Export Error", str(e))
         return False
+
+    @staticmethod
+    def _export_to_sql(parent, tracks: Tracks, name: str, rebind: bool):
+        """Write the tracks to a SQLite database, optionally switching to it.
+
+        The destination is cleared before writing rather than being handed to
+        tracksdata as an overwrite: exporting a database that is itself SQL-backed
+        takes a fast SQL-level copy that requires an empty destination, and that
+        is exactly the case where the graph may be too big to copy through Python.
+
+        Returns:
+            Tracks | bool: The rebound tracks if the user asked to keep editing in
+                the database, True on a plain export, False if nothing was written.
+        """
+        file_dialog = QFileDialog(parent, "Save as SQL database")
+        file_dialog.setFileMode(QFileDialog.AnyFile)
+        file_dialog.setAcceptMode(QFileDialog.AcceptSave)
+        file_dialog.setNameFilter(f"SQLite database (*{SQL_SUFFIX})")
+        file_dialog.setDefaultSuffix(SQL_SUFFIX.lstrip("."))
+        file_dialog.selectFile(str(Path.home() / f"{name}_tracks{SQL_SUFFIX}"))
+
+        if not file_dialog.exec_():
+            return False
+
+        file_path = Path(file_dialog.selectedFiles()[0])
+        if file_path == sql_database_path(tracks):
+            QMessageBox.warning(
+                parent,
+                "Export Error",
+                "These tracks are already stored in that database. Choose a "
+                "different file to export a copy.",
+            )
+            return False
+
+        try:
+            if file_path.exists():
+                file_path.unlink()
+            graph = write_tracks_to_sql(tracks, file_path)
+        except (OSError, ValueError) as e:
+            QMessageBox.warning(parent, "Export Error", str(e))
+            return False
+
+        if not rebind:
+            return True
+        return rebind_tracks_to_graph(tracks, graph)

--- a/src/motile_tracker/import_export/menus/export_dialog.py
+++ b/src/motile_tracker/import_export/menus/export_dialog.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
 
 from motile_tracker.import_export.sql_io import (
     SQL_SUFFIX,
+    is_same_database,
     is_sql_backed,
     rebind_tracks_to_graph,
     sql_database_path,
@@ -167,8 +168,10 @@ class ExportTypeDialog(QDialog):
     def rebind(self) -> bool:
         """Whether to switch the session over to the database being written.
 
-        The checkbox asks the opposite question - whether to stay in memory - so
-        that leaving it alone exports without changing anything.
+        The checkbox asks the opposite question - whether to stay put - so that
+        the default always leaves the user working in a database: in-memory
+        tracks move to the new one (unticked), tracks already in a database stay
+        in the one they are in (ticked).
         """
         return not self.keep_in_memory_checkbox.isChecked()
 
@@ -358,7 +361,7 @@ class ExportDialog:
             return False
 
         file_path = Path(file_dialog.selectedFiles()[0])
-        if file_path == sql_database_path(tracks):
+        if is_same_database(file_path, tracks):
             QMessageBox.warning(
                 parent,
                 "Export Error",
@@ -368,9 +371,7 @@ class ExportDialog:
             return False
 
         try:
-            if file_path.exists():
-                file_path.unlink()
-            graph = write_tracks_to_sql(tracks, file_path)
+            graph = write_tracks_to_sql(tracks, file_path, overwrite=True)
         except (OSError, ValueError) as e:
             QMessageBox.warning(parent, "Export Error", str(e))
             return False

--- a/src/motile_tracker/import_export/sql_io.py
+++ b/src/motile_tracker/import_export/sql_io.py
@@ -22,6 +22,7 @@ running application.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -65,7 +66,35 @@ def sql_database_path(tracks: Tracks) -> Path | None:
     return Path(database) if database else None
 
 
-def write_tracks_to_sql(tracks: Tracks, path: Path) -> td.graph.SQLGraph:
+def is_same_database(path: Path, tracks: Tracks) -> bool:
+    """Whether `path` names the database the given tracks already live in.
+
+    Exporting a database over itself would clear the way before reading it, so
+    this has to catch the same file spelled differently: a symlinked parent
+    (on macOS /tmp is a link to /private/tmp) or, on a case-insensitive
+    filesystem, different capitalisation. ``samefile`` compares the underlying
+    file and is the reliable test when both paths exist; resolving covers the
+    case where the destination does not exist yet.
+
+    Args:
+        path (Path): The proposed destination.
+        tracks (Tracks): The tracks being exported.
+    """
+    current = sql_database_path(tracks)
+    if current is None:
+        return False
+    try:
+        return os.path.samefile(path, current)
+    except OSError:
+        # One of them does not exist, so they cannot be the same file - but
+        # resolve anyway, since a not-yet-created path can still spell an
+        # existing one via a symlinked parent.
+        return Path(path).resolve() == Path(current).resolve()
+
+
+def write_tracks_to_sql(
+    tracks: Tracks, path: Path, overwrite: bool = False
+) -> td.graph.SQLGraph:
     """Write tracks to a SQLite database at the given path.
 
     Writes ``graph_full``, not ``graph_solution``, so soft-deleted candidates
@@ -73,31 +102,60 @@ def write_tracks_to_sql(tracks: Tracks, path: Path) -> td.graph.SQLGraph:
     already drops candidates and marks everything ``solution=True`` again; the
     database format should not repeat that.
 
-    The destination must not already hold data. tracksdata copies a SQLite
-    source to a SQLite destination with ``ATTACH DATABASE``, never materialising
-    the graph, but only when the destination file is absent or empty and
-    ``overwrite`` is not set. Asking the caller to clear the path first (having
-    confirmed with the user) keeps that fast path available for tracks that are
-    themselves already SQL-backed.
+    tracksdata copies a SQLite source to a SQLite destination with
+    ``ATTACH DATABASE``, never materialising the graph, but only when the
+    destination is absent or empty. So replacing an existing database means
+    clearing the way first, and doing that in place would destroy the old file
+    before knowing the new one can be written. Instead the graph is written to a
+    temporary file beside the destination and moved over it once complete: a
+    failed export leaves whatever was there untouched.
 
     Args:
         tracks (Tracks): The tracks to write.
         path (Path): The database file to create.
+        overwrite (bool): Whether to replace a database already at `path`.
 
     Returns:
-        td.graph.SQLGraph: The graph that was written, open and ready to be
-            handed to :func:`rebind_tracks_to_graph`.
+        td.graph.SQLGraph: The graph that was written, open at `path` and ready
+            to be handed to :func:`rebind_tracks_to_graph`.
 
     Raises:
-        FileExistsError: If something is already at `path`.
+        FileExistsError: If something is already at `path` and `overwrite` is
+            False.
     """
     path = Path(path)
-    if path.exists() and path.stat().st_size > 0:
+    occupied = path.exists() and path.stat().st_size > 0
+    if occupied and not overwrite:
         raise FileExistsError(
             f"{path} already exists. Remove it before writing a database there."
         )
 
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not occupied:
+        path.unlink(missing_ok=True)  # an empty file still blocks ATTACH
+        return _write_new_database(tracks, path)
+
+    # Write beside the destination, on the same filesystem so the move is
+    # atomic, and only then replace. Nothing touches `path` until the new
+    # database is complete on disk.
+    staged = path.with_name(f".{path.name}.exporting")
+    staged.unlink(missing_ok=True)
+    try:
+        graph = _write_new_database(tracks, staged)
+        # Drop the connection before moving: the reopened graph below must be
+        # the one the caller edits through, not one still bound to `staged`.
+        graph._engine.dispose()
+        os.replace(staged, path)
+    except BaseException:
+        staged.unlink(missing_ok=True)
+        raise
+
+    return td.graph.SQLGraph(drivername=DRIVERNAME, database=str(path))
+
+
+def _write_new_database(tracks: Tracks, path: Path) -> td.graph.SQLGraph:
+    """Copy the full graph into a database at a path known to be free."""
     graph = td.graph.SQLGraph.from_other(
         tracks.graph_full,
         drivername=DRIVERNAME,

--- a/src/motile_tracker/import_export/sql_io.py
+++ b/src/motile_tracker/import_export/sql_io.py
@@ -145,13 +145,41 @@ def write_tracks_to_sql(
         graph = _write_new_database(tracks, staged)
         # Drop the connection before moving: the reopened graph below must be
         # the one the caller edits through, not one still bound to `staged`.
-        graph._engine.dispose()
-        os.replace(staged, path)
+        close_database(graph)
+        try:
+            os.replace(staged, path)
+        except OSError as err:
+            # Windows refuses to rename over a file that anything still holds
+            # open, where POSIX would replace it and leave the other reader on
+            # a deleted inode. Neither outcome is wanted, so report the cause
+            # rather than the errno.
+            raise OSError(
+                f"Could not replace {path}: something still has it open. "
+                f"Another set of tracks in this session may be stored there, "
+                f"in which case export to a different file instead."
+            ) from err
     except BaseException:
         staged.unlink(missing_ok=True)
         raise
 
     return td.graph.SQLGraph(drivername=DRIVERNAME, database=str(path))
+
+
+def close_database(graph_or_tracks: td.graph.BaseGraph | Tracks) -> None:
+    """Release a database's connections.
+
+    SQLAlchemy engines are not closed when the object goes out of scope, and
+    while an engine is alive Windows will not let the file be renamed over or
+    deleted. Anything that stops using a database should say so.
+
+    No-op for an in-memory graph, so callers need not check first.
+
+    Args:
+        graph_or_tracks: A tracksdata graph, or tracks holding one.
+    """
+    graph = getattr(graph_or_tracks, "graph_full", graph_or_tracks)
+    if isinstance(graph, td.graph.SQLGraph):
+        graph._engine.dispose()
 
 
 def _write_new_database(tracks: Tracks, path: Path) -> td.graph.SQLGraph:

--- a/src/motile_tracker/import_export/sql_io.py
+++ b/src/motile_tracker/import_export/sql_io.py
@@ -1,0 +1,235 @@
+"""Reading and writing tracks as an on-disk tracksdata SQL database.
+
+A funtracks ``Tracks`` holds a tracksdata graph, which may be an in-memory
+``IndexedRXGraph`` or a database-backed ``SQLGraph``. The SQL backend is
+interesting for three reasons: the file on disk is always in sync, so a crash
+loses nothing; several annotators can work against one database; and the
+candidate graph (the ``solution=False`` nodes) does not have to fit in RAM.
+
+Import never converts: CSV and geff always build in-memory graphs. The only way
+into the SQL backend is to open a database that already exists, or to export one
+and optionally carry on editing in it.
+
+Note that SQL does not make the *solution* out-of-core. ``Tracks`` builds
+``graph_solution`` as a ``GraphView``, which subclasses ``RustWorkXGraph``, so
+for a SQL root it is materialised in memory. What lives on disk is the full
+graph. Restricting the solution view to a time window is the follow-up that
+makes the memory benefit real.
+
+This module deliberately holds no Qt, so the round trip can be tested without a
+running application.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import tracksdata as td
+from funtracks.data_model import Tracks
+
+SQL_SUFFIX = ".db"
+
+DRIVERNAME = "sqlite"
+
+# Graph metadata key holding what a database cannot otherwise say about itself.
+#
+# ``Tracks`` recovers nodes, edges, attributes and (via ``shape`` plus the
+# ``mask`` attribute) the segmentation straight from the graph, but not the
+# scale or which attribute keys are time, position and track id. Those go here,
+# under one namespaced key so nothing collides with tracksdata's own metadata.
+META_KEY = "motile_tracker"
+
+
+def is_sql_backed(tracks: Tracks) -> bool:
+    """Whether the tracks are stored in a database rather than in memory.
+
+    Args:
+        tracks (Tracks): The tracks to inspect.
+    """
+    return isinstance(tracks.graph_full, td.graph.SQLGraph)
+
+
+def sql_database_path(tracks: Tracks) -> Path | None:
+    """The database file backing the given tracks, or None if in memory.
+
+    Reaches into ``SQLGraph._url``, which tracksdata does not expose publicly.
+    Kept in one place so there is a single site to update if it ever does.
+
+    Args:
+        tracks (Tracks): The tracks to inspect.
+    """
+    if not is_sql_backed(tracks):
+        return None
+    database = tracks.graph_full._url.database
+    return Path(database) if database else None
+
+
+def write_tracks_to_sql(tracks: Tracks, path: Path) -> td.graph.SQLGraph:
+    """Write tracks to a SQLite database at the given path.
+
+    Writes ``graph_full``, not ``graph_solution``, so soft-deleted candidates
+    survive. A database exists to be reopened and edited, and a geff round trip
+    already drops candidates and marks everything ``solution=True`` again; the
+    database format should not repeat that.
+
+    The destination must not already hold data. tracksdata copies a SQLite
+    source to a SQLite destination with ``ATTACH DATABASE``, never materialising
+    the graph, but only when the destination file is absent or empty and
+    ``overwrite`` is not set. Asking the caller to clear the path first (having
+    confirmed with the user) keeps that fast path available for tracks that are
+    themselves already SQL-backed.
+
+    Args:
+        tracks (Tracks): The tracks to write.
+        path (Path): The database file to create.
+
+    Returns:
+        td.graph.SQLGraph: The graph that was written, open and ready to be
+            handed to :func:`rebind_tracks_to_graph`.
+
+    Raises:
+        FileExistsError: If something is already at `path`.
+    """
+    path = Path(path)
+    if path.exists() and path.stat().st_size > 0:
+        raise FileExistsError(
+            f"{path} already exists. Remove it before writing a database there."
+        )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    graph = td.graph.SQLGraph.from_other(
+        tracks.graph_full,
+        drivername=DRIVERNAME,
+        database=str(path),
+    )
+    graph.metadata[META_KEY] = _describe(tracks)
+    return graph
+
+
+def tracks_from_sql(path: Path, scale: list[float] | None = None) -> Tracks:
+    """Open an existing SQLite database as tracks.
+
+    The database is opened in place, not copied: every later edit is written
+    straight to this file. ``SQLGraph`` reflects the existing schema back when
+    ``overwrite`` is false, which is the default.
+
+    A database that records no scale opens without one. Tracks with no scale are
+    an ordinary state throughout the application - loading a geff produces them
+    too - so there is nothing to ask the user about here.
+
+    Args:
+        path (Path): An existing database file.
+        scale (list[float] | None): Scale to use, overriding whatever the
+            database records.
+
+    Returns:
+        Tracks: Tracks backed by the database.
+    """
+    graph = td.graph.SQLGraph(drivername=DRIVERNAME, database=str(Path(path)))
+    described = graph.metadata.get(META_KEY) or {}
+
+    if scale is None:
+        scale = described.get("scale")
+
+    return Tracks(
+        graph,
+        time_attr=described.get("time_attr") or _sniff_time_attr(graph),
+        pos_attr=described.get("pos_attr") or _sniff_pos_attr(graph),
+        tracklet_attr=described.get("tracklet_attr"),
+        lineage_attr=described.get("lineage_attr"),
+        scale=scale,
+        ndim=described.get("ndim"),
+    )
+
+
+def rebind_tracks_to_graph(tracks: Tracks, graph: td.graph.BaseGraph) -> Tracks:
+    """Return tracks of the same kind, backed by the given graph.
+
+    Used after exporting to a database, when the user asked to carry on editing
+    in it. Building a new object rather than swapping ``graph_full`` in place
+    keeps the graph/view/annotator wiring entirely in funtracks' hands.
+
+    The new object starts with an empty action history, so **undo and redo are
+    cleared**: the actions on the old stack hold references into the old graph
+    and cannot be replayed against the new one. Callers must tell the user.
+
+    Args:
+        tracks (Tracks): The tracks to rebind. Its own graph is left alone.
+        graph (td.graph.BaseGraph): The graph to bind to.
+
+    Returns:
+        Tracks: A new object carrying over everything about `tracks` that is not
+            stored in the graph. A MotileRun rebinds to a MotileRun so its solver
+            params survive; anything else rebinds to a plain Tracks, which is
+            what every other loader in this package returns.
+    """
+    # Imported here rather than at module level: motile.backend imports
+    # geff_io from this package, and MotileRun is only needed on this path.
+    from motile_tracker.motile.backend.motile_run import MotileRun
+
+    if isinstance(tracks, MotileRun):
+        return MotileRun(
+            graph,
+            run_name=tracks.run_name,
+            scale=tracks.scale,
+            ndim=tracks.ndim,
+            solver_params=tracks.solver_params,
+            input_segmentation=tracks.input_segmentation,
+            input_points=tracks.input_points,
+            time=tracks.time,
+            gaps=tracks.gaps,
+            status=tracks.status,
+            _features=tracks.features,
+        )
+
+    return Tracks(
+        graph,
+        scale=tracks.scale,
+        ndim=tracks.ndim,
+        features=tracks.features,
+    )
+
+
+def _describe(tracks: Tracks) -> dict[str, Any]:
+    """What to record in the database beyond the graph itself.
+
+    The feature keys matter as much as the scale: ``Tracks`` defaults its time
+    attribute to "time", but every funtracks graph calls it "t", so a database
+    reopened without them would be given the wrong FeatureDict.
+    """
+    features = tracks.features
+    return {
+        "scale": list(tracks.scale) if tracks.scale is not None else None,
+        "ndim": tracks.ndim,
+        "time_attr": features.time_key,
+        "pos_attr": features.position_key,
+        "tracklet_attr": features.tracklet_key,
+        "lineage_attr": features.lineage_key,
+    }
+
+
+def _sniff_time_attr(graph: td.graph.BaseGraph) -> str:
+    """Guess the time attribute of a database written by something else.
+
+    funtracks graphs use "t"; "time" is the funtracks default and worth trying
+    second so a graph built elsewhere still opens.
+    """
+    keys = graph.node_attr_keys()
+    for candidate in ("t", "time"):
+        if candidate in keys:
+            return candidate
+    return "t"
+
+
+def _sniff_pos_attr(graph: td.graph.BaseGraph) -> str | list[str]:
+    """Guess the position attribute(s) of a database written by something else.
+
+    A single "pos" array is the funtracks convention; one column per axis is the
+    other shape funtracks accepts, so fall back to whichever axis columns exist.
+    """
+    keys = graph.node_attr_keys()
+    if "pos" in keys:
+        return "pos"
+    axes = [axis for axis in ("z", "y", "x") if axis in keys]
+    return axes if axes else "pos"

--- a/src/motile_tracker/import_export/sql_io.py
+++ b/src/motile_tracker/import_export/sql_io.py
@@ -10,6 +10,11 @@ Import never converts: CSV and geff always build in-memory graphs. The only way
 into the SQL backend is to open a database that already exists, or to export one
 and optionally carry on editing in it.
 
+A database written elsewhere - say Ultrack - can be opened too, and the
+``_sniff_*`` helpers below exist for that case: they recover from the graph and
+its metadata what a database nTE wrote would have stated outright. Note that
+opening such a database writes to it; see :func:`tracks_from_sql`.
+
 Note that SQL does not make the *solution* out-of-core. ``Tracks`` builds
 ``graph_solution`` as a ``GraphView``, which subclasses ``RustWorkXGraph``, so
 for a SQL root it is materialised in memory. What lives on disk is the full
@@ -25,13 +30,25 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
+import numpy as np
 import tracksdata as td
 from funtracks.data_model import Tracks
 
 SQL_SUFFIX = ".db"
 
 DRIVERNAME = "sqlite"
+
+# The value a tracksdata id column holds before anything has computed it. Shared
+# by tracklet, lineage and track id columns, and what funtracks checks for when
+# deciding whether existing ids can be trusted.
+UNCOMPUTED_ID = -1
+
+# How many nodes to read when cross-checking two position attributes against
+# each other. The question is whether a column means anything at all, which a
+# spread of a few hundred rows answers as well as all of them would.
+_POS_SAMPLE_SIZE = 512
 
 # Graph metadata key holding what a database cannot otherwise say about itself.
 #
@@ -200,6 +217,13 @@ def tracks_from_sql(path: Path, scale: list[float] | None = None) -> Tracks:
     straight to this file. ``SQLGraph`` reflects the existing schema back when
     ``overwrite`` is false, which is the default.
 
+    Opening is **not** read-only. ``Tracks`` adds the ``solution`` node and edge
+    attribute keys if the graph has none, which is an ``ALTER TABLE``, and it
+    computes and writes back any track ids the graph only pretends to have (see
+    :func:`_repair_uncomputed_lineage_ids`). A database written by nTE already
+    has everything, so nothing happens; a foreign database is written to by
+    being opened. Copy the file first if that matters.
+
     A database that records no scale opens without one. Tracks with no scale are
     an ordinary state throughout the application - loading a geff produces them
     too - so there is nothing to ask the user about here.
@@ -216,9 +240,9 @@ def tracks_from_sql(path: Path, scale: list[float] | None = None) -> Tracks:
     described = graph.metadata.get(META_KEY) or {}
 
     if scale is None:
-        scale = described.get("scale")
+        scale = described.get("scale") or _sniff_scale(graph)
 
-    return Tracks(
+    tracks = Tracks(
         graph,
         time_attr=described.get("time_attr") or _sniff_time_attr(graph),
         pos_attr=described.get("pos_attr") or _sniff_pos_attr(graph),
@@ -227,6 +251,8 @@ def tracks_from_sql(path: Path, scale: list[float] | None = None) -> Tracks:
         scale=scale,
         ndim=described.get("ndim"),
     )
+    _repair_uncomputed_lineage_ids(tracks)
+    return tracks
 
 
 def rebind_tracks_to_graph(tracks: Tracks, graph: td.graph.BaseGraph) -> Tracks:
@@ -308,14 +334,120 @@ def _sniff_time_attr(graph: td.graph.BaseGraph) -> str:
     return "t"
 
 
+def _sniff_scale(graph: td.graph.BaseGraph) -> list[float] | None:
+    """The scale of a database that spells the scale metadata differently.
+
+    Nothing is needed here for a database that follows the tracksdata
+    convention: funtracks already backs ``Tracks.scale`` with
+    ``graph_full.metadata["scale"]``, treats it as **spatial-only** and adds the
+    dummy time entry itself.
+
+    Ultrack writes the same key with the time scale included - one entry per
+    axis of the segmentation, e.g. ``[1, 1.97, 0.485, 0.485]`` for t/z/y/x.
+    Handing that to funtracks unchanged makes it prepend a further entry and
+    then refuse to open the database at all ("Dimensions from segmentation 4,
+    scale 5, and ndim 4 must match"), so the clash has to be resolved here.
+
+    Detected by length: as long as it equals the number of axes in the
+    segmentation shape, the leading entry is a time scale. Passing the value
+    through as the time-first scale ``Tracks`` accepts also rewrites the
+    metadata into the spatial-only form, so a database only needs this once.
+
+    Returns None when the metadata already follows the funtracks convention, or
+    when there is no scale to read; in both cases funtracks does the right thing
+    unaided.
+    """
+    scale = graph.metadata.get("scale")
+    shape = graph.metadata.get("shape") or graph.metadata.get("segmentation_shape")
+    if scale is None or shape is None or len(scale) != len(shape):
+        return None
+    warn(
+        f"Scale {list(scale)} in this database includes the time axis, which is "
+        f"not the convention funtracks reads it by. Treating the first entry as "
+        f"the time scale and rewriting the metadata without it.",
+        stacklevel=2,
+    )
+    return [float(value) for value in scale]
+
+
 def _sniff_pos_attr(graph: td.graph.BaseGraph) -> str | list[str]:
     """Guess the position attribute(s) of a database written by something else.
 
     A single "pos" array is the funtracks convention; one column per axis is the
-    other shape funtracks accepts, so fall back to whichever axis columns exist.
+    other shape funtracks accepts. With only one of the two present the answer is
+    obvious. With both, "pos" wins - unless it was never filled in, which is what
+    an Ultrack database looks like: a zeroed "pos" column next to real z/y/x
+    columns. Reading positions from that one puts every node at the origin, and
+    nothing says so until the points are on screen in the wrong place.
     """
     keys = graph.node_attr_keys()
-    if "pos" in keys:
-        return "pos"
     axes = [axis for axis in ("z", "y", "x") if axis in keys]
-    return axes if axes else "pos"
+    if not axes:
+        return "pos"
+    if "pos" in keys and _pos_is_populated(graph):
+        return "pos"
+    return axes
+
+
+def _pos_is_populated(graph: td.graph.BaseGraph) -> bool:
+    """True if the "pos" column holds anything other than zeros.
+
+    Only a sample is read: "pos" holds a pickled array per node, so reading the
+    whole column would pull hundreds of megabytes off disk to answer a question
+    a few hundred rows already answer. The sample is spread over the id range
+    rather than taken from the front, so a database that merely starts with
+    unpopulated rows is not misjudged.
+    """
+    node_ids = graph.node_ids()
+    if not node_ids:
+        return True
+    step = max(1, len(node_ids) // _POS_SAMPLE_SIZE)
+    sample = node_ids[::step][:_POS_SAMPLE_SIZE]
+
+    values = graph.filter(node_ids=sample).node_attrs(attr_keys=["pos"])["pos"]
+    return any(np.asarray(value).any() for value in values)
+
+
+def _repair_uncomputed_lineage_ids(tracks: Tracks) -> None:
+    """Recompute lineage ids that the graph only pretends to have.
+
+    TODO: this is a workaround for a funtracks bug and belongs there, not here.
+    ``Tracks._ensure_track_features`` sentinel-checks only the *tracklet* key
+    (via ``_has_uncomputed_track_ids``), so a graph whose tracklet ids are real
+    but whose lineage column was never filled in takes the "activate, do not
+    compute" branch, and the -1 default is then served as a genuine lineage id.
+    Every node reports lineage -1, which silently breaks lineage display mode
+    and groups. An Ultrack database is exactly this shape: valid tracklet_id,
+    untouched lineage_id. funtracks should apply the same sentinel check to the
+    lineage key that it already applies to the tracklet key. Once it does,
+    delete this function, its call in :func:`tracks_from_sql`, the
+    ``UNCOMPUTED_ID`` constant and the lineage tests in
+    ``TestUltrackShapedDatabase``.
+
+    The check runs on ``graph_solution``, which is already in memory by the time
+    ``Tracks`` returns, so it costs no extra database read - the same read
+    funtracks does for the tracklet key. The recompute, if needed, does write
+    the repaired ids back to the database.
+
+    Args:
+        tracks (Tracks): Freshly constructed tracks to check and, if needed, fix.
+    """
+    lineage_key = tracks.features.lineage_key
+    solution = tracks.graph_solution
+    if (
+        lineage_key is None
+        or solution.num_nodes() == 0
+        or lineage_key not in solution.node_attr_keys()
+    ):
+        return
+
+    values = solution.node_attrs(attr_keys=[lineage_key])[lineage_key]
+    if not bool((values == UNCOMPUTED_ID).any()):
+        return
+
+    warn(
+        f'Lineage ids ("{lineage_key}") in this database were never computed. '
+        f"Computing them from the graph and writing them back.",
+        stacklevel=2,
+    )
+    tracks.enable_features([lineage_key])

--- a/tests/data_views/test_track_labels.py
+++ b/tests/data_views/test_track_labels.py
@@ -360,3 +360,63 @@ def test_undo_on_readonly_data_does_not_fire_paint_event(
         "undo() on read-only data must restore the display buffer directly "
         "without emitting events.paint"
     )
+
+
+def test_paint_onto_existing_node_when_tracks_live_in_a_database(
+    viewer, graph_3d_with_division, tmp_path
+):
+    """Extending an existing node by painting must work on a SQL-backed graph.
+
+    napari stores selected_label as a numpy integer, and a SQL graph does not
+    match one against its integer node ids: has_node answered False for a node
+    that plainly exists. The paint was then routed down the "add a new node"
+    branch, which found the node already present and raised
+    "Node N is already in the view". Only databases were affected, because the
+    in-memory graph matches numpy and Python ints alike.
+
+    TrackLabels works around this by converting to a plain int. This test keeps
+    passing once tracksdata coerces numpy scalars itself and that workaround is
+    removed, since it asserts the behaviour rather than the conversion - so keep
+    it, and use it to check the removal is safe.
+    """
+    from funtracks.data_model import SolutionTracks, Tracks
+
+    from motile_tracker.import_export.sql_io import (
+        tracks_from_sql,
+        write_tracks_to_sql,
+    )
+
+    write_tracks_to_sql(
+        Tracks(graph_3d_with_division, ndim=4, time_attr="t"), tmp_path / "tracks.db"
+    )
+    on_disk = tracks_from_sql(tmp_path / "tracks.db")
+    tracks = SolutionTracks(
+        on_disk.graph_full,
+        ndim=on_disk.ndim,
+        features=on_disk.features,
+        _segmentation=on_disk.segmentation,
+    )
+
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=tracks, name="test")
+    seg_layer = tracks_viewer.tracking_layers.seg_layer
+    seg_layer.mode = "paint"
+
+    # Select an existing node and paint a few pixels next to it, at its own
+    # timepoint - the ordinary "grow this cell" edit.
+    node = 3
+    time = int(tracks.get_time(node))
+    step = list(viewer.dims.current_step)
+    step[0] = time
+    viewer.dims.current_step = step
+    seg_layer.selected_label = np.int64(node)  # what napari actually stores
+
+    nodes_before = tracks.graph.num_nodes()
+    event_val = create_event_val(
+        tp=time, z=(20, 22), y=(20, 22), x=(20, 22), old_val=0, target_val=node
+    )
+    seg_layer._on_paint(MockEvent(event_val))
+
+    # The node was extended, not added again.
+    assert tracks.graph.num_nodes() == nodes_before
+    assert tracks.graph.has_node(node)

--- a/tests/data_views/views_coordinator/test_tracks_list.py
+++ b/tests/data_views/views_coordinator/test_tracks_list.py
@@ -798,6 +798,19 @@ class TestTracksListOnDiskNote:
         assert tracks_list.on_disk_label.isVisibleTo(tracks_list)
         assert str(tracks_db) in tracks_list.on_disk_label.text()
 
+    def test_hidden_when_the_last_database_row_is_removed(self, tracks_list, tracks_db):
+        """Removing the row clears the selection, and the note must go with it.
+
+        Left up, it would keep claiming edits are being written to a database
+        that is no longer open anywhere.
+        """
+        tracks_list.add_tracks(tracks_from_sql(tracks_db), "on disk")
+        assert tracks_list.on_disk_label.isVisibleTo(tracks_list)
+
+        tracks_list.remove_tracks(tracks_list.tracks_list.item(0))
+
+        assert not tracks_list.on_disk_label.isVisibleTo(tracks_list)
+
     def test_hidden_again_when_an_in_memory_row_is_selected(
         self, tracks_list, tracks_db, solution_tracks_2d
     ):

--- a/tests/data_views/views_coordinator/test_tracks_list.py
+++ b/tests/data_views/views_coordinator/test_tracks_list.py
@@ -8,14 +8,22 @@ import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
+import tracksdata as td
 from funtracks.data_model import SolutionTracks, Tracks
 from funtracks.import_export import write_to_geff
 from qtpy.QtWidgets import QDialog
 
 from motile_tracker.data_views.views_coordinator.tracks_list import (
+    SQL_LOAD_OPTION,
     TracksButton,
     TracksList,
     default_save_dir,
+)
+from motile_tracker.import_export.sql_io import (
+    is_sql_backed,
+    sql_database_path,
+    tracks_from_sql,
+    write_tracks_to_sql,
 )
 from motile_tracker.motile.backend.motile_run import MotileRun, SolverParams
 
@@ -672,3 +680,183 @@ class TestTracksListExport:
             tracks_list.show_export_dialog(item)
 
         assert len(emitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# TracksList — SQL database
+# ---------------------------------------------------------------------------
+
+_GET_OPEN_FILE_NAME = (
+    "motile_tracker.data_views.views_coordinator.tracks_list."
+    "QFileDialog.getOpenFileName"
+)
+
+
+@pytest.fixture
+def tracks_db(graph_2d, tmp_path):
+    """A tracks database on disk, written the way the export dialog writes one.
+
+    Built with an explicit scale, because that is what a database written by
+    motile_tracker records and what keeps the load from having to ask.
+    """
+    path = tmp_path / "saved_tracks.db"
+    write_tracks_to_sql(
+        Tracks(graph_2d, ndim=3, time_attr="t", scale=[1.0, 0.5, 0.25]), path
+    )
+    return path
+
+
+class TestTracksListLoadSql:
+    def test_dropdown_offers_sql(self, tracks_list):
+        assert tracks_list.dropdown_menu.findText(SQL_LOAD_OPTION) != -1
+
+    def test_load_tracks_dispatches_sql(self, tracks_list):
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with patch.object(tracks_list, "load_sql_tracks", return_value=None) as mock:
+            tracks_list.load_tracks()
+            mock.assert_called_once()
+
+    def test_load_adds_database_backed_tracks(self, tracks_list, tracks_db):
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with patch(_GET_OPEN_FILE_NAME, return_value=(str(tracks_db), "")):
+            tracks_list.load_tracks()
+
+        assert tracks_list.tracks_list.count() == 1
+        widget = tracks_list.tracks_list.itemWidget(tracks_list.tracks_list.item(0))
+        assert widget.name.text() == "saved_tracks"
+        assert is_sql_backed(widget.tracks)
+        assert sql_database_path(widget.tracks) == tracks_db
+
+    def test_load_emits_tracks_loaded_with_database_path(self, tracks_list, tracks_db):
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        emitted = []
+        tracks_list.tracks_loaded.connect(lambda t, p: emitted.append((t, p)))
+
+        with patch(_GET_OPEN_FILE_NAME, return_value=(str(tracks_db), "")):
+            tracks_list.load_tracks()
+
+        assert len(emitted) == 1
+        assert emitted[0][1] == tracks_db
+
+    def test_load_cancelled_adds_nothing(self, tracks_list):
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with patch(_GET_OPEN_FILE_NAME, return_value=("", "")):
+            tracks_list.load_tracks()
+
+        assert tracks_list.tracks_list.count() == 0
+
+    def test_load_bad_path_warns(self, tracks_list, tmp_path):
+        not_a_database = tmp_path / "nope.db"
+        not_a_database.write_bytes(b"not a database")
+
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with (
+            patch(_GET_OPEN_FILE_NAME, return_value=(str(not_a_database), "")),
+            pytest.warns(UserWarning, match="Could not"),
+        ):
+            tracks_list.load_tracks()
+
+        assert tracks_list.tracks_list.count() == 0
+
+    def test_recorded_scale_is_restored(self, tracks_list, tracks_db):
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with patch(_GET_OPEN_FILE_NAME, return_value=(str(tracks_db), "")):
+            tracks_list.load_tracks()
+
+        widget = tracks_list.tracks_list.itemWidget(tracks_list.tracks_list.item(0))
+        assert widget.tracks.scale == [1.0, 0.5, 0.25]
+
+    def test_loads_without_asking_when_no_scale_is_recorded(
+        self, tracks_list, solution_tracks_2d, tmp_path
+    ):
+        """A database with no scale loads with none, exactly like a geff does.
+
+        Tracks with no scale are an ordinary state throughout the application, so
+        the load must not stop to ask - a modal here would also hang the suite.
+        """
+        foreign = tmp_path / "foreign.db"
+        td.graph.SQLGraph.from_other(
+            solution_tracks_2d.graph_full, drivername="sqlite", database=str(foreign)
+        )
+
+        tracks_list.dropdown_menu.setCurrentText(SQL_LOAD_OPTION)
+        with patch(_GET_OPEN_FILE_NAME, return_value=(str(foreign), "")):
+            tracks_list.load_tracks()
+
+        assert tracks_list.tracks_list.count() == 1
+        widget = tracks_list.tracks_list.itemWidget(tracks_list.tracks_list.item(0))
+        assert widget.tracks.scale is None
+
+
+class TestTracksListOnDiskNote:
+    def test_hidden_for_in_memory_tracks(self, tracks_list, solution_tracks_2d):
+        tracks_list.add_tracks(solution_tracks_2d, "in memory")
+        assert not tracks_list.on_disk_label.isVisibleTo(tracks_list)
+
+    def test_shown_for_database_backed_tracks(self, tracks_list, tracks_db):
+        tracks_list.add_tracks(tracks_from_sql(tracks_db), "on disk")
+        assert tracks_list.on_disk_label.isVisibleTo(tracks_list)
+        assert str(tracks_db) in tracks_list.on_disk_label.text()
+
+    def test_hidden_again_when_an_in_memory_row_is_selected(
+        self, tracks_list, tracks_db, solution_tracks_2d
+    ):
+        tracks_list.add_tracks(tracks_from_sql(tracks_db), "on disk")
+        tracks_list.add_tracks(solution_tracks_2d, "in memory")
+        assert not tracks_list.on_disk_label.isVisibleTo(tracks_list)
+
+
+class TestTracksListExportRebind:
+    def test_rebound_tracks_replace_the_row(
+        self, tracks_list, solution_tracks_2d, tracks_db
+    ):
+        """Exporting with 'continue editing' swaps the row over to the database."""
+        tracks_list.add_tracks(solution_tracks_2d, "run")
+        item = tracks_list.tracks_list.item(0)
+        rebound = tracks_from_sql(tracks_db)
+
+        with patch(
+            "motile_tracker.data_views.views_coordinator.tracks_list."
+            "ExportDialog.show_export_dialog",
+            return_value=rebound,
+        ):
+            tracks_list.show_export_dialog(item)
+
+        widget = tracks_list.tracks_list.itemWidget(item)
+        assert widget.tracks is rebound
+        assert tracks_list.on_disk_label.isVisibleTo(tracks_list)
+
+    def test_rebound_tracks_are_redisplayed(
+        self, tracks_list, solution_tracks_2d, tracks_db
+    ):
+        """Re-emitting view_tracks is what makes the layers and tree rebuild."""
+        tracks_list.add_tracks(solution_tracks_2d, "run")
+        item = tracks_list.tracks_list.item(0)
+        rebound = tracks_from_sql(tracks_db)
+
+        emitted = []
+        tracks_list.view_tracks.connect(lambda t, n: emitted.append(t))
+
+        with patch(
+            "motile_tracker.data_views.views_coordinator.tracks_list."
+            "ExportDialog.show_export_dialog",
+            return_value=rebound,
+        ):
+            tracks_list.show_export_dialog(item)
+
+        assert len(emitted) == 1
+        assert is_sql_backed(emitted[0])
+
+    def test_plain_export_leaves_the_row_alone(self, tracks_list, solution_tracks_2d):
+        tracks_list.add_tracks(solution_tracks_2d, "run")
+        item = tracks_list.tracks_list.item(0)
+
+        with patch(
+            "motile_tracker.data_views.views_coordinator.tracks_list."
+            "ExportDialog.show_export_dialog",
+            return_value=True,
+        ):
+            tracks_list.show_export_dialog(item)
+
+        widget = tracks_list.tracks_list.itemWidget(item)
+        assert widget.tracks is solution_tracks_2d

--- a/tests/import_export/test_export_dialog.py
+++ b/tests/import_export/test_export_dialog.py
@@ -1,12 +1,22 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import napari
 import numpy as np
 import pytest
+from funtracks.data_model import Tracks
+from qtpy.QtWidgets import QLabel
 
 from motile_tracker.import_export.menus.export_dialog import (
+    SQL_EXPORT_TYPE,
     ExportDialog,
     ExportTypeDialog,
+)
+from motile_tracker.import_export.sql_io import (
+    is_sql_backed,
+    sql_database_path,
+    tracks_from_sql,
+    write_tracks_to_sql,
 )
 
 # ---------------------------------------------------------------------------
@@ -442,3 +452,251 @@ def test_export_geff_error(
 
     assert result is False
     mock_warning.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# SQL database export
+# ---------------------------------------------------------------------------
+
+
+def _select_sql(dialog):
+    dialog.export_type_combo.setCurrentText(SQL_EXPORT_TYPE)
+
+
+def _select_sql_and_rebind(dialog):
+    # Switching over is the default, so selecting the format is all it takes.
+    _select_sql(dialog)
+
+
+def _select_sql_and_stay(dialog):
+    _select_sql(dialog)
+    dialog.keep_in_memory_checkbox.setChecked(True)
+
+
+def test_sql_offered_by_default(qtbot):
+    dialog = ExportTypeDialog(has_segmentation=True)
+    qtbot.addWidget(dialog)
+    assert dialog.export_type_combo.findText(SQL_EXPORT_TYPE) != -1
+
+
+def test_sql_hidden_for_group_export(qtbot):
+    """A group export writes a subset; a database is written whole."""
+    dialog = ExportTypeDialog(has_segmentation=True, offer_sql=False)
+    qtbot.addWidget(dialog)
+    assert dialog.export_type_combo.findText(SQL_EXPORT_TYPE) == -1
+
+
+def test_rebind_option_only_shown_for_sql(qtbot):
+    dialog = ExportTypeDialog(has_segmentation=True)
+    qtbot.addWidget(dialog)
+    assert not dialog.keep_in_memory_checkbox.isVisibleTo(dialog)
+
+    _select_sql(dialog)
+    assert dialog.keep_in_memory_checkbox.isVisibleTo(dialog)
+    assert dialog._rebind_label.isVisibleTo(dialog)
+
+
+def test_in_memory_tracks_switch_over_by_default(qtbot):
+    """Exporting from memory leaves you working in the new database."""
+    dialog = ExportTypeDialog(has_segmentation=True)
+    qtbot.addWidget(dialog)
+    _select_sql(dialog)
+
+    assert not dialog.keep_in_memory_checkbox.isChecked()
+    assert dialog.rebind is True
+
+    dialog.keep_in_memory_checkbox.setChecked(True)
+    assert dialog.rebind is False
+
+
+def test_database_backed_tracks_stay_put_by_default(qtbot):
+    """Exporting a copy of a database must not move the session into the copy.
+
+    The default never leaves you in memory, but for tracks already on disk that
+    means staying where they are, not following the copy being handed over.
+    """
+    dialog = ExportTypeDialog(
+        has_segmentation=True, already_on_disk=Path("/data/tracks.db")
+    )
+    qtbot.addWidget(dialog)
+    _select_sql(dialog)
+
+    assert dialog.keep_in_memory_checkbox.isChecked()
+    assert dialog.rebind is False
+
+    dialog.keep_in_memory_checkbox.setChecked(False)
+    assert dialog.rebind is True
+
+
+def test_sql_hides_segmentation_options(qtbot):
+    """A database always holds the segmentation, as part of the graph."""
+    dialog = ExportTypeDialog(has_segmentation=True)
+    qtbot.addWidget(dialog)
+    dialog.seg_checkbox.setChecked(True)
+
+    _select_sql(dialog)
+
+    assert not dialog.seg_checkbox.isVisibleTo(dialog)
+    assert not dialog.save_segmentation
+
+
+def test_export_to_sql_writes_a_readable_database(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    db_path = tmp_path / "tracks.db"
+    accept_type_dialog(_select_sql_and_stay)
+
+    with mock_file_dialog(db_path):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, solution_tracks_2d, name="G", colormap=colormap
+        )
+
+    assert result is True
+    assert db_path.exists()
+    reopened = tracks_from_sql(db_path)
+    assert reopened.graph_full.num_nodes() == (
+        solution_tracks_2d.graph_full.num_nodes()
+    )
+
+
+def test_export_to_sql_without_rebind_leaves_session_in_memory(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    accept_type_dialog(_select_sql_and_stay)
+
+    with mock_file_dialog(tmp_path / "tracks.db"):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, solution_tracks_2d, name="G", colormap=colormap
+        )
+
+    assert result is True  # a plain export, nothing to swap in
+    assert not is_sql_backed(solution_tracks_2d)
+
+
+def test_export_to_sql_with_rebind_returns_database_backed_tracks(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    db_path = tmp_path / "tracks.db"
+    accept_type_dialog(_select_sql_and_rebind)
+
+    with mock_file_dialog(db_path):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, solution_tracks_2d, name="G", colormap=colormap
+        )
+
+    assert isinstance(result, Tracks)
+    assert is_sql_backed(result)
+    assert sql_database_path(result) == db_path
+    # The object handed in is left alone.
+    assert not is_sql_backed(solution_tracks_2d)
+
+
+def test_export_to_sql_overwrites_existing_file(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    """The save dialog already confirmed; clearing the path first is what keeps
+    tracksdata's SQL-level copy eligible."""
+    db_path = tmp_path / "tracks.db"
+    db_path.write_bytes(b"not a database")
+    accept_type_dialog(_select_sql_and_stay)
+
+    with mock_file_dialog(db_path):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, solution_tracks_2d, name="G", colormap=colormap
+        )
+
+    assert result is True
+    assert tracks_from_sql(db_path).graph_full.num_nodes() > 0
+
+
+def test_export_to_sql_refuses_own_database(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    """Exporting a database over itself would destroy it before reading it."""
+    db_path = tmp_path / "tracks.db"
+    write_tracks_to_sql(solution_tracks_2d, db_path)
+    opened = tracks_from_sql(db_path)
+
+    accept_type_dialog(_select_sql)
+    with (
+        mock_file_dialog(db_path),
+        patch(
+            "motile_tracker.import_export.menus.export_dialog.QMessageBox.warning"
+        ) as mock_warning,
+    ):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, opened, name="G", colormap=colormap
+        )
+
+    assert result is False
+    mock_warning.assert_called_once()
+    assert tracks_from_sql(db_path).graph_full.num_nodes() > 0
+
+
+def test_export_to_sql_cancel_writes_nothing(
+    solution_tracks_2d, fake_parent, tmp_path, colormap, accept_type_dialog
+):
+    db_path = tmp_path / "tracks.db"
+    accept_type_dialog(_select_sql)
+
+    fd = MagicMock()
+    fd.exec_.return_value = False
+    with patch(
+        "motile_tracker.import_export.menus.export_dialog.QFileDialog",
+        return_value=fd,
+    ):
+        result = ExportDialog.show_export_dialog(
+            fake_parent, solution_tracks_2d, name="G", colormap=colormap
+        )
+
+    assert result is False
+    assert not db_path.exists()
+
+
+def test_already_on_disk_note_shown_for_database_backed_tracks(
+    solution_tracks_2d,
+    fake_parent,
+    tmp_path,
+    colormap,
+    accept_type_dialog,
+    mock_file_dialog,
+):
+    """Tracks that live in a database are told so, since for them exporting is
+    about sharing rather than about not losing work."""
+    db_path = tmp_path / "tracks.db"
+    write_tracks_to_sql(solution_tracks_2d, db_path)
+    opened = tracks_from_sql(db_path)
+
+    captured = accept_type_dialog(_select_sql)
+    with mock_file_dialog(tmp_path / "copy.db"):
+        ExportDialog.show_export_dialog(
+            fake_parent, opened, name="G", colormap=colormap
+        )
+
+    labels = captured["dialog"].findChildren(QLabel)
+    assert any(str(db_path) in label.text() for label in labels)

--- a/tests/import_export/test_sql_io.py
+++ b/tests/import_export/test_sql_io.py
@@ -15,6 +15,7 @@ from funtracks.user_actions import UserDeleteNodes
 from motile_tracker.import_export import sql_io
 from motile_tracker.import_export.sql_io import (
     META_KEY,
+    close_database,
     is_same_database,
     is_sql_backed,
     rebind_tracks_to_graph,
@@ -196,7 +197,11 @@ class TestOverwrite:
 
     def test_overwrite_replaces_contents(self, tracks_2d, graph_3d, tmp_path):
         path = tmp_path / "tracks.db"
-        write_tracks_to_sql(Tracks(graph_3d, ndim=4, time_attr="t"), path)
+        # Released because Windows will not rename over an open file, which is
+        # exactly the precondition the export path relies on.
+        close_database(
+            write_tracks_to_sql(Tracks(graph_3d, ndim=4, time_attr="t"), path)
+        )
 
         write_tracks_to_sql(tracks_2d, path, overwrite=True)
 
@@ -209,11 +214,35 @@ class TestOverwrite:
         staging path every later edit would be written to the wrong file.
         """
         path = tmp_path / "tracks.db"
-        write_tracks_to_sql(tracks_2d, path)
+        close_database(write_tracks_to_sql(tracks_2d, path))
 
         graph = write_tracks_to_sql(tracks_2d, path, overwrite=True)
 
         assert Path(graph._url.database) == path
+        assert not list(tmp_path.glob(".*.exporting"))
+
+    def test_overwriting_an_open_database_is_refused_clearly(
+        self, tracks_2d, tmp_path, monkeypatch
+    ):
+        """Replacing a database something else still holds open must not happen.
+
+        Windows raises WinError 5 here; POSIX would silently replace the file
+        and leave the other reader writing to a deleted inode. Both are reported
+        as the same explicit refusal, so the message does not depend on the
+        platform the user happens to be on.
+        """
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(tracks_2d, path)  # deliberately left open
+        before = path.read_bytes()
+
+        def deny(*args, **kwargs):
+            raise PermissionError("[WinError 5] Access is denied")
+
+        monkeypatch.setattr(sql_io.os, "replace", deny)
+        with pytest.raises(OSError, match="still has it open"):
+            write_tracks_to_sql(tracks_2d, path, overwrite=True)
+
+        assert path.read_bytes() == before
         assert not list(tmp_path.glob(".*.exporting"))
 
     def test_failed_overwrite_leaves_the_original(

--- a/tests/import_export/test_sql_io.py
+++ b/tests/import_export/test_sql_io.py
@@ -4,14 +4,18 @@ No Qt here: sql_io deliberately holds no widgets, so the format itself can be
 tested without a running application.
 """
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 import tracksdata as td
 from funtracks.data_model import Tracks
 from funtracks.user_actions import UserDeleteNodes
 
+from motile_tracker.import_export import sql_io
 from motile_tracker.import_export.sql_io import (
     META_KEY,
+    is_same_database,
     is_sql_backed,
     rebind_tracks_to_graph,
     sql_database_path,
@@ -185,6 +189,83 @@ class TestForeignDatabase:
             3.0,
             3.0,
         ]
+
+
+class TestOverwrite:
+    """Replacing a database must never destroy the old one on failure."""
+
+    def test_overwrite_replaces_contents(self, tracks_2d, graph_3d, tmp_path):
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(Tracks(graph_3d, ndim=4, time_attr="t"), path)
+
+        write_tracks_to_sql(tracks_2d, path, overwrite=True)
+
+        assert tracks_from_sql(path).ndim == 3
+
+    def test_returned_graph_is_open_at_the_real_path(self, tracks_2d, tmp_path):
+        """Overwriting stages a temp file; the caller must get the final one.
+
+        Rebinding hands this graph to Tracks, so if it were still bound to the
+        staging path every later edit would be written to the wrong file.
+        """
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(tracks_2d, path)
+
+        graph = write_tracks_to_sql(tracks_2d, path, overwrite=True)
+
+        assert Path(graph._url.database) == path
+        assert not list(tmp_path.glob(".*.exporting"))
+
+    def test_failed_overwrite_leaves_the_original(
+        self, tracks_2d, tmp_path, monkeypatch
+    ):
+        """A write that blows up must not take the existing database with it."""
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(tracks_2d, path)
+        before = path.read_bytes()
+
+        monkeypatch.setattr(
+            sql_io,
+            "_write_new_database",
+            lambda *a, **k: (_ for _ in ()).throw(ValueError("boom")),
+        )
+        with pytest.raises(ValueError, match="boom"):
+            write_tracks_to_sql(tracks_2d, path, overwrite=True)
+
+        assert path.read_bytes() == before
+        assert not list(tmp_path.glob(".*.exporting"))
+
+
+class TestSameDatabase:
+    """The guard standing between an export and the user's only copy."""
+
+    @pytest.fixture
+    def opened(self, tracks_2d, tmp_path):
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        return tracks_from_sql(tmp_path / "tracks.db")
+
+    def test_exact_path(self, opened, tmp_path):
+        assert is_same_database(tmp_path / "tracks.db", opened)
+
+    def test_different_file(self, opened, tmp_path):
+        assert not is_same_database(tmp_path / "other.db", opened)
+
+    def test_in_memory_tracks_are_never_the_same(self, tracks_2d, tmp_path):
+        assert not is_same_database(tmp_path / "tracks.db", tracks_2d)
+
+    def test_symlinked_parent(self, opened, tmp_path):
+        """Plain Path equality misses this; on macOS /tmp is a link already."""
+        link = tmp_path / "link"
+        link.symlink_to(tmp_path, target_is_directory=True)
+
+        assert is_same_database(link / "tracks.db", opened)
+
+    def test_nonexistent_path_through_a_symlinked_parent(self, opened, tmp_path):
+        """samefile cannot help when the destination does not exist yet."""
+        link = tmp_path / "link"
+        link.symlink_to(tmp_path, target_is_directory=True)
+
+        assert not is_same_database(link / "missing.db", opened)
 
 
 class TestWriteGuards:

--- a/tests/import_export/test_sql_io.py
+++ b/tests/import_export/test_sql_io.py
@@ -1,0 +1,280 @@
+"""Round-tripping tracks through an on-disk SQL database.
+
+No Qt here: sql_io deliberately holds no widgets, so the format itself can be
+tested without a running application.
+"""
+
+import numpy as np
+import pytest
+import tracksdata as td
+from funtracks.data_model import Tracks
+from funtracks.user_actions import UserDeleteNodes
+
+from motile_tracker.import_export.sql_io import (
+    META_KEY,
+    is_sql_backed,
+    rebind_tracks_to_graph,
+    sql_database_path,
+    tracks_from_sql,
+    write_tracks_to_sql,
+)
+from motile_tracker.motile.backend.motile_run import MotileRun
+from motile_tracker.motile.backend.solver_params import SolverParams
+
+
+@pytest.fixture
+def tracks_2d(graph_2d) -> Tracks:
+    """2D+time tracks with a segmentation and a non-trivial scale."""
+    return Tracks(graph_2d, ndim=3, time_attr="t", scale=[1.0, 0.5, 0.25])
+
+
+class TestRoundTrip:
+    def test_graph_survives(self, tracks_2d, tmp_path):
+        """Nodes, edges and node ids all come back."""
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+
+        assert isinstance(reopened.graph_full, td.graph.SQLGraph)
+        assert reopened.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
+        assert reopened.graph_full.num_edges() == tracks_2d.graph_full.num_edges()
+        # Node ids must be preserved, not just the count: the segmentation is
+        # rendered by looking node ids up as label values.
+        assert sorted(reopened.graph_full.node_ids()) == sorted(
+            tracks_2d.graph_full.node_ids()
+        )
+
+    def test_description_survives(self, tracks_2d, tmp_path):
+        """Scale, ndim and the feature keys are not in the graph, so they are
+        recorded separately and must come back."""
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+
+        assert reopened.scale == tracks_2d.scale
+        assert reopened.ndim == tracks_2d.ndim
+        assert reopened.features.time_key == tracks_2d.features.time_key
+        assert reopened.features.position_key == tracks_2d.features.position_key
+        assert reopened.features.tracklet_key == tracks_2d.features.tracklet_key
+        assert reopened.features.lineage_key == tracks_2d.features.lineage_key
+
+    def test_segmentation_survives(self, tracks_2d, tmp_path):
+        """The segmentation is rebuilt from the masks and the shape metadata,
+        with no side file."""
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+
+        assert reopened.segmentation is not None
+        np.testing.assert_array_equal(
+            np.asarray(reopened.segmentation), np.asarray(tracks_2d.segmentation)
+        )
+
+    def test_3d_round_trip(self, graph_3d, tmp_path):
+        tracks = Tracks(graph_3d, ndim=4, time_attr="t", scale=[1.0, 2.0, 0.5, 0.5])
+        write_tracks_to_sql(tracks, tmp_path / "tracks.db")
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+
+        assert reopened.ndim == 4
+        assert reopened.scale == [1.0, 2.0, 0.5, 0.5]
+        np.testing.assert_array_equal(
+            np.asarray(reopened.segmentation), np.asarray(tracks.segmentation)
+        )
+
+    def test_candidates_survive(self, tracks_2d, tmp_path):
+        """Soft-deleted nodes are kept as candidates, unlike in a geff round trip.
+
+        This is why the database is written from graph_full. It does not make the
+        delete undoable after reopening - the action history is not part of the
+        graph - but it does mean the node is still there to be reconnected, and
+        that the solver's candidate set is intact.
+        """
+        victim = sorted(tracks_2d.graph_solution.node_ids())[-1]
+        UserDeleteNodes(tracks_2d, [victim])
+        assert tracks_2d.graph_full.num_nodes() > tracks_2d.graph_solution.num_nodes()
+
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+
+        assert reopened.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
+        assert reopened.graph_solution.num_nodes() == (
+            tracks_2d.graph_solution.num_nodes()
+        )
+        assert victim in reopened.graph_full.node_ids()
+        assert victim not in reopened.graph_solution.node_ids()
+
+    def test_sql_to_sql(self, tracks_2d, tmp_path):
+        """Exporting a database-backed tracks to another database.
+
+        Takes tracksdata's SQL-level copy rather than going through Python,
+        which is the path that matters for a graph too big to materialise.
+        """
+        write_tracks_to_sql(tracks_2d, tmp_path / "first.db")
+        first = tracks_from_sql(tmp_path / "first.db")
+
+        write_tracks_to_sql(first, tmp_path / "second.db")
+        second = tracks_from_sql(tmp_path / "second.db")
+
+        assert second.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
+        assert second.scale == tracks_2d.scale
+        np.testing.assert_array_equal(
+            np.asarray(second.segmentation), np.asarray(tracks_2d.segmentation)
+        )
+
+
+class TestLiveEditing:
+    def test_edit_reaches_disk(self, tracks_2d, tmp_path):
+        """An edit to database-backed tracks is on disk without any save."""
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        opened = tracks_from_sql(tmp_path / "tracks.db")
+        victim = sorted(opened.graph_solution.node_ids())[-1]
+
+        UserDeleteNodes(opened, [victim])
+
+        # Nothing was saved; open the same file again from scratch.
+        reopened = tracks_from_sql(tmp_path / "tracks.db")
+        assert victim not in reopened.graph_solution.node_ids()
+
+    def test_segmentation_stays_fresh(self, tracks_2d, tmp_path):
+        """Editing a database-backed graph updates the rendered segmentation.
+
+        Guards the tracksdata root-to-view propagation this feature depends on:
+        the segmentation reads from graph_solution, which for a SQL root is a
+        separate copy, so without propagation it would silently render stale.
+        """
+        write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        opened = tracks_from_sql(tmp_path / "tracks.db")
+        before = np.asarray(opened.segmentation).copy()
+
+        victim = sorted(opened.graph_solution.node_ids())[-1]
+        UserDeleteNodes(opened, [victim])
+
+        after = np.asarray(opened.segmentation)
+        assert not np.array_equal(before, after)
+        assert victim not in np.unique(after)
+
+
+class TestForeignDatabase:
+    """A database written by something other than motile_tracker."""
+
+    @pytest.fixture
+    def foreign_db(self, tracks_2d, tmp_path):
+        path = tmp_path / "foreign.db"
+        td.graph.SQLGraph.from_other(
+            tracks_2d.graph_full, drivername="sqlite", database=str(path)
+        )
+        return path
+
+    def test_opens_with_sniffed_keys(self, foreign_db, tracks_2d):
+        """Without a recorded description the attribute keys are guessed.
+
+        Tracks defaults its time attribute to "time", but funtracks graphs call
+        it "t", so guessing is what keeps such a database loadable at all.
+        """
+        reopened = tracks_from_sql(foreign_db)
+
+        assert reopened.features.time_key == "t"
+        assert reopened.features.position_key == "pos"
+        assert reopened.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
+
+    def test_opens_without_a_scale(self, foreign_db):
+        """No scale recorded means no scale, same as loading a geff."""
+        assert tracks_from_sql(foreign_db).scale is None
+
+    def test_scale_can_be_supplied(self, foreign_db):
+        """A caller that knows the scale can pass it in."""
+        assert tracks_from_sql(foreign_db, scale=[1.0, 3.0, 3.0]).scale == [
+            1.0,
+            3.0,
+            3.0,
+        ]
+
+
+class TestWriteGuards:
+    def test_refuses_existing_file(self, tracks_2d, tmp_path):
+        """The caller clears the destination, so the SQL-level copy stays usable."""
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(tracks_2d, path)
+
+        with pytest.raises(FileExistsError):
+            write_tracks_to_sql(tracks_2d, path)
+
+    def test_writes_over_empty_file(self, tracks_2d, tmp_path):
+        """A zero-byte file is what a save dialog leaves behind, not real data."""
+        path = tmp_path / "tracks.db"
+        path.touch()
+
+        write_tracks_to_sql(tracks_2d, path)
+        assert tracks_from_sql(path).graph_full.num_nodes() > 0
+
+    def test_records_description_under_one_key(self, tracks_2d, tmp_path):
+        """Everything recorded is namespaced, so nothing collides with
+        tracksdata's own metadata."""
+        graph = write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+
+        assert META_KEY in graph.metadata
+        assert "shape" in graph.metadata  # copied by tracksdata, not by us
+
+
+class TestBackendQueries:
+    def test_in_memory_tracks(self, tracks_2d):
+        assert not is_sql_backed(tracks_2d)
+        assert sql_database_path(tracks_2d) is None
+
+    def test_database_backed_tracks(self, tracks_2d, tmp_path):
+        path = tmp_path / "tracks.db"
+        write_tracks_to_sql(tracks_2d, path)
+        reopened = tracks_from_sql(path)
+
+        assert is_sql_backed(reopened)
+        assert sql_database_path(reopened) == path
+
+
+class TestRebind:
+    def test_switches_backend_and_keeps_description(self, tracks_2d, tmp_path):
+        graph = write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+
+        rebound = rebind_tracks_to_graph(tracks_2d, graph)
+
+        assert is_sql_backed(rebound)
+        assert sql_database_path(rebound) == tmp_path / "tracks.db"
+        assert rebound.scale == tracks_2d.scale
+        assert rebound.ndim == tracks_2d.ndim
+        assert rebound.features.time_key == tracks_2d.features.time_key
+
+    def test_leaves_the_original_alone(self, tracks_2d, tmp_path):
+        graph = write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+
+        rebind_tracks_to_graph(tracks_2d, graph)
+
+        assert not is_sql_backed(tracks_2d)
+
+    def test_clears_undo_history(self, tracks_2d, tmp_path):
+        """The old actions reference the old graph and cannot be replayed."""
+        victim = sorted(tracks_2d.graph_solution.node_ids())[-1]
+        UserDeleteNodes(tracks_2d, [victim])
+        assert len(tracks_2d.action_history.undo_stack) > 0
+
+        graph = write_tracks_to_sql(tracks_2d, tmp_path / "tracks.db")
+        rebound = rebind_tracks_to_graph(tracks_2d, graph)
+
+        assert len(rebound.action_history.undo_stack) == 0
+
+    def test_motile_run_keeps_its_run(self, graph_2d, tmp_path):
+        """A solved run rebinds to a run, so its solver params are not lost."""
+        params = SolverParams(max_edge_distance=42.0)
+        run = MotileRun(
+            graph_2d,
+            run_name="a run",
+            time_attr="t",
+            ndim=3,
+            solver_params=params,
+            gaps=[0.1],
+        )
+
+        graph = write_tracks_to_sql(run, tmp_path / "run.db")
+        rebound = rebind_tracks_to_graph(run, graph)
+
+        assert isinstance(rebound, MotileRun)
+        assert rebound.run_name == "a run"
+        assert rebound.solver_params.max_edge_distance == 42.0
+        assert rebound.gaps == [0.1]
+        assert rebound.time == run.time
+        assert is_sql_backed(rebound)

--- a/tests/import_export/test_sql_io.py
+++ b/tests/import_export/test_sql_io.py
@@ -4,9 +4,11 @@ No Qt here: sql_io deliberately holds no widgets, so the format itself can be
 tested without a running application.
 """
 
+import warnings
 from pathlib import Path
 
 import numpy as np
+import polars as pl
 import pytest
 import tracksdata as td
 from funtracks.data_model import Tracks
@@ -179,12 +181,21 @@ class TestForeignDatabase:
         assert reopened.features.position_key == "pos"
         assert reopened.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
 
+    def test_scale_comes_back_from_the_graph_metadata(self, foreign_db, tracks_2d):
+        """A database with no description still knows its own scale.
+
+        funtracks backs Tracks.scale with graph_full.metadata["scale"], which
+        SQLGraph.from_other copies, so this needs nothing from sql_io. The test
+        pins that down because sql_io must not "helpfully" pass a scale of its
+        own - the metadata is spatial-only and funtracks adds the time entry, so
+        passing the raw value through would double it up.
+        """
+        assert tracks_from_sql(foreign_db).scale == tracks_2d.scale
+
     def test_opens_without_a_scale(self, foreign_db):
         """No scale recorded anywhere means no scale, same as loading a geff.
 
-        funtracks backs Tracks.scale with graph_full.metadata["scale"], which
-        SQLGraph.from_other copies, so a database written from scaled tracks
-        arrives with a scale of its own. Clear it to get the unscaled case.
+        ndim still resolves, from the segmentation shape metadata.
         """
         graph = td.graph.SQLGraph(drivername="sqlite", database=str(foreign_db))
         del graph.metadata["scale"]
@@ -199,6 +210,188 @@ class TestForeignDatabase:
             3.0,
             3.0,
         ]
+
+    def test_scale_including_time_is_normalised(self, foreign_db):
+        """Ultrack records one scale entry per axis, time included.
+
+        funtracks reads that key as spatial-only and adds the time entry itself,
+        so left alone it ends up with one entry too many and refuses to open the
+        database at all.
+        """
+        graph = td.graph.SQLGraph(drivername="sqlite", database=str(foreign_db))
+        graph.metadata["scale"] = [1.0, 2.0, 4.0]  # t, y, x - shape is (5, 100, 100)
+        close_database(graph)
+
+        with pytest.warns(UserWarning, match="includes the time axis"):
+            reopened = tracks_from_sql(foreign_db)
+
+        assert reopened.scale == [1.0, 2.0, 4.0]
+        # Rewritten into the funtracks convention, so it is a one-time repair.
+        assert reopened.graph_full.metadata["scale"] == [2.0, 4.0]
+
+    def test_supplied_scale_beats_the_recorded_one(self, foreign_db):
+        graph = td.graph.SQLGraph(drivername="sqlite", database=str(foreign_db))
+        graph.metadata["scale"] = [1.0, 2.0, 4.0]
+        close_database(graph)
+
+        assert tracks_from_sql(foreign_db, scale=[1.0, 9.0, 9.0]).scale == [
+            1.0,
+            9.0,
+            9.0,
+        ]
+
+
+class TestUltrackShapedDatabase:
+    """The shape an Ultrack database arrives in.
+
+    Three things are wrong with it in ways that raise nothing: the scale sits at
+    the top level of the metadata, the "pos" column exists but was never filled
+    in while the real coordinates live in per-axis columns, and the lineage
+    column holds nothing but the uncomputed sentinel next to perfectly good
+    tracklet ids.
+    """
+
+    @pytest.fixture
+    def ultrack_db(self, tracks_2d, tmp_path):
+        """A database with Ultrack's attribute layout, built from tracks_2d.
+
+        Deliberately assembled by mutating a database rather than by writing a
+        fixture graph: the point is to reproduce what arrives on disk.
+        """
+        path = tmp_path / "ultrack.db"
+        graph = td.graph.SQLGraph.from_other(
+            tracks_2d.graph_full, drivername="sqlite", database=str(path)
+        )
+        node_ids = graph.node_ids()
+        positions = graph.filter(node_ids=node_ids).node_attrs(attr_keys=["pos"])["pos"]
+
+        for axis in ("y", "x"):
+            graph.add_node_attr_key(axis, dtype=pl.Float64, default_value=-1.0)
+        graph.update_node_attrs(
+            attrs={
+                "y": [float(pos[0]) for pos in positions],
+                "x": [float(pos[1]) for pos in positions],
+                # The column Ultrack leaves behind: present, allocated, zero.
+                "pos": [np.zeros(2, dtype=float) for _ in node_ids],
+                "lineage_id": [sql_io.UNCOMPUTED_ID] * len(node_ids),
+            },
+            node_ids=node_ids,
+        )
+        # Ultrack's spelling: one entry per axis, time included.
+        graph.metadata["scale"] = [1.0, 0.5, 0.25]
+        close_database(graph)
+        return path
+
+    def test_axis_columns_win_over_an_unfilled_pos(self, ultrack_db, tracks_2d):
+        """Positions must come from y/x, not from the zeroed "pos" column.
+
+        Preferring "pos" because it exists is what puts every node at the
+        origin, and nothing about that failure is visible until the points are
+        on screen in the wrong place.
+        """
+        reopened = tracks_from_sql(ultrack_db)
+
+        assert reopened.features.position_key == ["y", "x"]
+        positions = reopened.get_positions(reopened.graph_solution.node_ids())
+        np.testing.assert_allclose(
+            np.sort(positions, axis=0),
+            np.sort(
+                tracks_2d.get_positions(tracks_2d.graph_solution.node_ids()), axis=0
+            ),
+        )
+
+    def test_scale_is_recovered(self, ultrack_db):
+        assert tracks_from_sql(ultrack_db).scale == [1.0, 0.5, 0.25]
+
+    def test_uncomputed_lineage_ids_are_replaced(self, ultrack_db):
+        """An all-sentinel lineage column must not be served as real lineages.
+
+        funtracks sentinel-checks the tracklet key but not the lineage key, so
+        without the repair every node reports lineage -1 and lineage mode and
+        groups are wrong while looking fine.
+        """
+        with pytest.warns(UserWarning, match="never computed"):
+            reopened = tracks_from_sql(ultrack_db)
+
+        lineage_key = reopened.features.lineage_key
+        values = reopened.graph_solution.node_attrs(attr_keys=[lineage_key])[
+            lineage_key
+        ]
+        assert sql_io.UNCOMPUTED_ID not in values.to_list()
+        # graph_2d is one lineage plus one unconnected node.
+        assert len(set(values.to_list())) == 2
+
+    def test_repaired_lineage_ids_reach_the_database(self, ultrack_db):
+        """The repair is a real edit, so reopening must not need it again."""
+        with pytest.warns(UserWarning, match="never computed"):
+            reopened = tracks_from_sql(ultrack_db)
+        close_database(reopened)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            tracks_from_sql(ultrack_db)
+
+    def test_good_tracklet_ids_are_kept(self, ultrack_db, tracks_2d):
+        """Repairing lineages must not discard the tracklet ids that were fine.
+
+        Ultrack's tracklets are the one part of its output worth keeping, and
+        the recompute path funtracks takes for a bad tracklet column would
+        renumber them.
+        """
+        with pytest.warns(UserWarning, match="never computed"):
+            reopened = tracks_from_sql(ultrack_db)
+
+        node_ids = sorted(reopened.graph_solution.node_ids())
+        assert list(reopened.get_track_ids(node_ids)) == list(
+            tracks_2d.get_track_ids(node_ids)
+        )
+
+
+class TestPositionSniffing:
+    """Choosing between a "pos" array and per-axis columns."""
+
+    def test_pos_is_preferred_when_it_is_populated(self, tracks_2d, tmp_path):
+        """Both columns filled in: keep the funtracks convention."""
+        path = tmp_path / "both.db"
+        graph = td.graph.SQLGraph.from_other(
+            tracks_2d.graph_full, drivername="sqlite", database=str(path)
+        )
+        node_ids = graph.node_ids()
+        positions = graph.filter(node_ids=node_ids).node_attrs(attr_keys=["pos"])["pos"]
+        for axis in ("y", "x"):
+            graph.add_node_attr_key(axis, dtype=pl.Float64, default_value=-1.0)
+        graph.update_node_attrs(
+            attrs={
+                "y": [float(pos[0]) for pos in positions],
+                "x": [float(pos[1]) for pos in positions],
+            },
+            node_ids=node_ids,
+        )
+        close_database(graph)
+
+        assert tracks_from_sql(path).features.position_key == "pos"
+
+    def test_pos_wins_over_axis_columns_that_disagree(self, tracks_2d, tmp_path):
+        """A populated "pos" is trusted; the axis columns are not cross-checked.
+
+        Deliberately not adjudicated: only the zeroed-"pos" case is a shape a
+        real database arrives in, and comparing every position against every
+        axis column to catch a hypothetical stale one is not worth the read.
+        """
+        path = tmp_path / "conflict.db"
+        graph = td.graph.SQLGraph.from_other(
+            tracks_2d.graph_full, drivername="sqlite", database=str(path)
+        )
+        node_ids = graph.node_ids()
+        for axis in ("y", "x"):
+            graph.add_node_attr_key(axis, dtype=pl.Float64, default_value=-1.0)
+        graph.update_node_attrs(
+            attrs={"y": [7.0] * len(node_ids), "x": [9.0] * len(node_ids)},
+            node_ids=node_ids,
+        )
+        close_database(graph)
+
+        assert tracks_from_sql(path).features.position_key == "pos"
 
 
 class TestOverwrite:

--- a/tests/import_export/test_sql_io.py
+++ b/tests/import_export/test_sql_io.py
@@ -180,7 +180,16 @@ class TestForeignDatabase:
         assert reopened.graph_full.num_nodes() == tracks_2d.graph_full.num_nodes()
 
     def test_opens_without_a_scale(self, foreign_db):
-        """No scale recorded means no scale, same as loading a geff."""
+        """No scale recorded anywhere means no scale, same as loading a geff.
+
+        funtracks backs Tracks.scale with graph_full.metadata["scale"], which
+        SQLGraph.from_other copies, so a database written from scaled tracks
+        arrives with a scale of its own. Clear it to get the unscaled case.
+        """
+        graph = td.graph.SQLGraph(drivername="sqlite", database=str(foreign_db))
+        del graph.metadata["scale"]
+        close_database(graph)
+
         assert tracks_from_sql(foreign_db).scale is None
 
     def test_scale_can_be_supplied(self, foreign_db):


### PR DESCRIPTION
## SQL-backed tracks

Tracks can now live in an on-disk tracksdata `SQLGraph` instead of in memory. Every edit is written to the file as it is made, so a crash loses nothing, several people can annotate one database, and the candidate graph does not have to fit in RAM.

### Changes

- **New** `import_export/sql_io.py` — read/write/rebind helpers, no Qt so the format is testable on its own.
- **Load**: `SQL database` in the results-list dropdown opens a `.db` in place.
- **Export**: `SQL database` format. By default the session switches over to the file  just written; a checkbox keeps you where you are. Exporting from a database defaults the other way, since a copy is normally for handing over.
- **Import is unchanged** — CSV and geff always build in-memory graphs.
- **Save is unchanged** — still writes a geff, for every backend. Database-backed tracks show their path so it is clear saving is for snapshots, not for safety.

A database holds `graph_full`, so candidate nodes survive a round trip (a geff export drops them). It also records scale, ndim and the time/position/track-id attribute keys, so it reopens without prompting. Undo history is not persisted, and switching over clears it.

### Notes

- `pyproject.toml` carries a **temporary** git pin to funtracks `149b9d7` (the `sql` branch, funkelab/funtracks#270), which itself pins tracksdata to `graph-views` (royerlab/tracksdata#325). Not releasable until both land.
- SQL does not make the *solution* out-of-core: `graph_solution` is a `GraphView`, which subclasses `RustWorkXGraph`, so it is materialised in memory even for a SQL root. Only the full graph is on disk. A time-windowed solution view is the follow-up that realises the memory benefit — and the same mechanism that lets annotators take disjoint time ranges.
- SQL is not offered for group export, which writes a node subset.

- existing `tracks.geff` can be converted to a database with the following two-liner: 

```
from tracksdata.graph import SQLGraph
graph, meta = SQLGraph.from_geff("tracks.geff", drivername="sqlite", database="out.db", overwrite=True)
```
(This sometimes fails for older geffs, so let me know if it doesn't work)
