### PR TITLE
Change dims sliders according to reference tracklet ID

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 
 dependencies =[
     "napari>=0.6.2,<0.8.0",
-    "funtracks>=2.1.0-a3,<3",
+    "funtracks @ git+https://github.com/funkelab/funtracks.git@refs/pull/281/head",
     "appdirs>=1,<2",
     "numpy>=2,<3",
     "magicgui>=0.10.1",
@@ -44,7 +44,7 @@ dependencies =[
     "dask[array]>=2021.10.0",
     "fonticon-fontawesome6>=6,<7",
     "pyqtgraph>=0.13,<1",
-    "napari-orthogonal-views>=0.4.0",
+    "napari-orthogonal-views>=0.4.2",
     "lxml_html_clean>=0.4,<1",
     "zarr>=2.18.7,<4",
 ]

--- a/src/motile_tracker/application_menus/visualization_widget.py
+++ b/src/motile_tracker/application_menus/visualization_widget.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import (
     QCheckBox,
     QGroupBox,
     QHBoxLayout,
+    QPushButton,
     QRadioButton,
     QSizePolicy,
     QVBoxLayout,
@@ -132,6 +133,81 @@ class ModeWidget(QWidget):
             self.update_mode.emit(button.property("mode"))
 
 
+class ReferenceTrackWidget(QWidget):
+    """Button that toggles the active tracklet ID as reference track.
+
+    While a reference track is set, stepping to another time point with the napari
+    slider shifts the view by the displacement of that track between the two time
+    points. The button shows the reference track ID and carries a border in its color.
+    """
+
+    def __init__(self, tracks_viewer: TracksViewer):
+        super().__init__()
+
+        self.tracks_viewer = tracks_viewer
+        self.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
+
+        self.reference_btn = QPushButton()
+        self.reference_btn.setToolTip(
+            "Follow the active tracklet when stepping through time with the slider: "
+            "the view moves along with the cell. Click again with the same tracklet "
+            "active to stop following it."
+        )
+        self.reference_btn.clicked.connect(self._toggle_reference)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(8, 6, 8, 6)
+        layout.setSpacing(6)
+        layout.addWidget(self.reference_btn)
+        self.tracks_viewer.update_track_id.connect(
+            lambda: self.reference_btn.setEnabled(
+                self.tracks_viewer.selected_track is not None
+            )
+        )
+        self.tracks_viewer.reference_track_updated.connect(self._update_display)
+        self._update_display()
+
+    def _toggle_reference(self) -> None:
+        """Make the active tracklet the reference track, or clear the reference when it
+        already is the reference track."""
+
+        selected = self.tracks_viewer.selected_track
+        if selected is not None and selected == self.tracks_viewer.reference_track:
+            selected = None
+        self.tracks_viewer.set_reference_track(selected)
+
+    def _update_display(self) -> None:
+        """Show the reference track ID on the button and mark it with its color"""
+
+        reference = self.tracks_viewer.reference_track
+        self.reference_btn.setText(f"Reference Track: {reference}")
+
+        if reference is None:
+            self.reference_btn.setStyleSheet(
+                """
+            QPushButton {
+                border: 2px solid rgba(0,0,0,0);
+                border-radius: 3px;
+                padding: 5px;
+            }
+            """
+            )
+            return
+
+        color = self.tracks_viewer.reference_track_color
+        r, g, b, a = [int(c * 255) if i < 3 else c for i, c in enumerate(color)]
+        css_color = f"rgba({r}, {g}, {b}, {a})"
+        self.reference_btn.setStyleSheet(
+            f"""
+            QPushButton {{
+                border: 2px solid {css_color};
+                border-radius: 3px;
+                padding: 5px;
+            }}
+            """
+        )
+
+
 class VisualizationWidget(QWidget):
     """Widget to adjust opacity and contour display in different TrackLabels layer display modes."""
 
@@ -172,10 +248,13 @@ class VisualizationWidget(QWidget):
 
         self.background_widget.setEnabled(False)  # initially disabled
 
+        self.reference_track_widget = ReferenceTrackWidget(self.tracks_viewer)
+
         main_layout.addWidget(self.mode_widget)
         main_layout.addWidget(self.highlight_widget)
         main_layout.addWidget(self.foreground_widget)
         main_layout.addWidget(self.background_widget)
+        main_layout.addWidget(self.reference_track_widget)
 
         self.show_ortho_views = QCheckBox("Orthogonal views")
         self.show_ortho_views.stateChanged.connect(self.initialize_ortho_views)
@@ -184,7 +263,7 @@ class VisualizationWidget(QWidget):
         main_layout.addWidget(self.show_ortho_views)
         main_layout.addStretch(1)
 
-        self.setMaximumHeight(360)
+        self.setMaximumHeight(480)
 
     def initialize_ortho_views(self, checked: bool):
         """Initializes the ortho views."""

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -152,8 +152,9 @@ class TracksLayerGroup:
             )
 
             # Set dims.point directly with world coordinates - napari will
-            # automatically convert to the correct step indices
-            self.viewer.dims.point = location
+            # automatically convert to the correct step indices.
+            with self.tracks_viewer.block_reference_shift():
+                self.viewer.dims.point = location
 
             # check whether the new coordinates are inside or outside the field of view,
             # then adjust the camera if needed

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Optional
 
 import napari
+import numpy as np
 import pandas as pd
 from funtracks.actions import AddNode, BasicAction, DeleteNode
 from funtracks.data_model import SolutionTracks
@@ -52,6 +54,7 @@ class TracksViewer:
 
     tracks_updated = Signal(Optional[bool])  # noqa: UP007 UP045
     update_track_id = Signal()
+    reference_track_updated = Signal()
     mode_updated = Signal()
     center_node = Signal(int)  # emitted when any component wants to center on a node
     node_selection_updated = Signal(bool)
@@ -117,11 +120,19 @@ class TracksViewer:
         self.track_id_color = [0, 0, 0, 0]
         self.force = False
 
+        # Reference track: when set, stepping through time with the napari slider
+        # shifts the view along with this track
+        self.reference_track: int | None = None
+        self.reference_track_color = [0, 0, 0, 0]
+        self._reference_shift_blocked = False
+        self._last_dims_state: tuple[float, tuple[int, ...]] | None = None
+
         self.collection_widget = None
 
         self.set_keybinds()
 
         self.viewer.dims.events.ndisplay.connect(self.update_selection)
+        self.viewer.dims.events.point.connect(self._on_dims_point_changed)
 
     def get_collection_widget(self) -> CollectionWidget:
         """Return a reference to the groups widget"""
@@ -174,6 +185,100 @@ class TracksViewer:
         self.track_id_color = (
             [0, 0, 0, 0] if track_id is None else self.colormap.map(track_id)
         )
+
+    def set_reference_track(self, track_id: int | None) -> None:
+        """Set (or clear, when track_id is None) the track that the view follows when
+        stepping through time with the napari slider. Also updates the color used to
+        mark the reference track in the UI."""
+
+        if track_id is not None and (
+            self.tracks is None or track_id not in self.tracks.track_id_to_node
+        ):
+            track_id = None
+
+        self.reference_track = track_id
+        self.reference_track_color = (
+            [0, 0, 0, 0] if track_id is None else self.colormap.map(track_id)
+        )
+        self.reference_track_updated.emit()
+
+    @contextmanager
+    def block_reference_shift(self):
+        """Set a mark to block the reference shift when the viewer dims changes because of
+        any other dims changing events that do not originate from the user moving the
+         viewer slider."""
+
+        previous = self._reference_shift_blocked
+        self._reference_shift_blocked = True
+        try:
+            yield
+        finally:
+            self._reference_shift_blocked = previous
+
+    def _dims_state(self) -> tuple[float, tuple[int, ...]]:
+        """The time point of the viewer plus the slider positions of the other
+        dimensions."""
+
+        dims = self.viewer.dims
+        return (dims.point[0], tuple(dims.current_step[1:]))
+
+    def _on_dims_point_changed(self, event=None) -> None:
+        """Shift the view along with the reference track when the user steps to another
+        time point with the napari slider. Skip if the dims change was triggered by
+        something else.
+        """
+
+        state = self._dims_state()
+        previous = self._last_dims_state
+        self._last_dims_state = state
+
+        if self._reference_shift_blocked or self.reference_track is None:
+            return
+        if previous is None or self.viewer.dims.ndim < 2:
+            return
+
+        previous_time, previous_sliders = previous
+        new_time, new_sliders = state
+        if previous_sliders != new_sliders or previous_time == new_time:
+            return
+
+        self._shift_view_along_reference(
+            int(round(previous_time)), int(round(new_time))
+        )
+
+    def _shift_view_along_reference(self, previous_time: int, new_time: int) -> None:
+        """Move the viewer along by the displacement of the reference track between the
+        two time points.
+
+        Every spatial dimension of dims.point is shifted, the displayed ones included so
+        that the ortho views can also follow.
+
+        Does nothing if the reference track has no node at one of the two time points.
+        """
+
+        nodes = self.tracks.get_track_nodes_at_times(
+            self.reference_track, (previous_time, new_time)
+        )
+        if previous_time not in nodes or new_time not in nodes:
+            return
+
+        start = np.asarray(self.tracks.get_position(nodes[previous_time]), dtype=float)
+        end = np.asarray(self.tracks.get_position(nodes[new_time]), dtype=float)
+
+        shift = end - start
+        dims = self.viewer.dims
+        if len(shift) != dims.ndim - 1:
+            return
+
+        point = list(dims.point)
+        for axis, offset in enumerate(shift, start=1):
+            point[axis] += offset
+        if tuple(point) == tuple(dims.point):
+            return
+
+        with self.block_reference_shift():
+            dims.point = point
+        self._last_dims_state = self._dims_state()
 
     def update_track_df(
         self, initialization: bool | None = False, refresh_view: bool | None = False
@@ -242,6 +347,10 @@ class TracksViewer:
 
         self.update_track_df(initialization=False, refresh_view=refresh_view)
 
+        # the reference track may have been edited or removed; revalidate and rebuild
+        # its cached positions
+        self.set_reference_track(self.reference_track)
+
         self.tracks_updated.emit(refresh_view)
 
         # if a new node was added, we would like to select this one now (call this after
@@ -277,6 +386,7 @@ class TracksViewer:
             name (str): The name of the tracks to display in the layer names
         """
         self.selected_nodes.reset()
+        self.set_reference_track(None)
 
         self._disconnect_tracks()
 

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -256,9 +256,10 @@ class TracksViewer:
         Does nothing if the reference track has no node at one of the two time points.
         """
 
-        nodes = self.tracks.get_track_nodes_at_times(
-            self.reference_track, (previous_time, new_time)
-        )
+        nodes = {
+            int(time): node
+            for time, node in self.tracks.get_track_node_times(self.reference_track)
+        }
         if previous_time not in nodes or new_time not in nodes:
             return
 

--- a/tests/data_views/views_coordinator/test_reference_track.py
+++ b/tests/data_views/views_coordinator/test_reference_track.py
@@ -1,0 +1,248 @@
+"""Tests for following a reference track when stepping through time."""
+
+import pytest
+
+from motile_tracker.application_menus.visualization_widget import VisualizationWidget
+from motile_tracker.data_views.views.ortho_views import initialize_ortho_views
+from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+
+
+@pytest.fixture
+def viewer(make_napari_viewer):
+    """Per-test viewer, because these tests inspect viewer.dims.point."""
+    return make_napari_viewer()
+
+
+@pytest.fixture
+def tracks_viewer(viewer, solution_tracks_3d_with_division):
+    """TracksViewer showing 3D+time tracks.
+
+    Track id 1 holds node 1 (t=0, pos [50, 50, 50]) and node 2 (t=1, pos
+    [20, 50, 80]), so its displacement from t=0 to t=1 is [-30, 0, 30]. It does
+    not exist at t=2, where the two daughter tracks start.
+    """
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    return tracks_viewer
+
+
+def _step_to(viewer, time: int) -> None:
+    """Move the time slider the way the user would."""
+    step = list(viewer.dims.current_step)
+    step[0] = time
+    viewer.dims.current_step = step
+
+
+def test_no_reference_track_keeps_z(viewer, tracks_viewer):
+    """Without a reference track, stepping in time leaves the other dims alone."""
+
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+
+    assert viewer.dims.point[1] == 50
+
+
+def test_reference_track_shifts_z(viewer, tracks_viewer):
+    """Stepping to the next time point shifts the z slider by the track's shift."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+
+    assert viewer.dims.point[0] == 1
+    assert viewer.dims.point[1] == 20  # 50 + (20 - 50)
+
+
+def test_reference_track_shift_is_relative(viewer, tracks_viewer):
+    """The shift is applied to the current view, not the track's absolute position."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 70, 50, 50)
+    _step_to(viewer, 1)
+
+    assert viewer.dims.point[1] == 40  # 70 + (20 - 50)
+
+
+def test_stepping_back_shifts_back(viewer, tracks_viewer):
+    """Stepping backwards shifts in the opposite direction."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+    _step_to(viewer, 0)
+
+    assert viewer.dims.point[1] == 50
+
+
+def test_missing_at_new_time_is_ignored(viewer, tracks_viewer):
+    """Track id 1 has no node at t=2, so stepping there leaves z untouched."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (1, 50, 50, 50)
+    _step_to(viewer, 2)
+
+    assert viewer.dims.point[1] == 50
+
+
+def test_centering_on_a_node_is_not_shifted(viewer, tracks_viewer):
+    """Moving to another time point by selecting a node must not shift the view.
+
+    Node 3 sits at t=2, [60, 50, 45], so centering has to land exactly there.
+    """
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    tracks_viewer.tracking_layers.center_view(3)
+
+    assert tuple(viewer.dims.point) == (2, 60, 50, 45)
+
+
+def test_shift_after_centering_uses_the_new_time(viewer, tracks_viewer):
+    """A centered jump updates the bookkeeping, so the next slider move is correct."""
+
+    tracks_viewer.set_reference_track(1)
+    tracks_viewer.tracking_layers.center_view(2)  # node 2, t=1, [20, 50, 80]
+    _step_to(viewer, 0)
+
+    assert viewer.dims.point[1] == 50  # 20 + (50 - 20)
+
+
+def test_single_axis_slider_move_shifts_z(viewer, tracks_viewer):
+    """The napari slider moves the time axis on its own; that is enough to trigger."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    viewer.dims.set_current_step(0, 1)
+
+    assert viewer.dims.point[1] == 20
+
+
+def test_displayed_dims_also_shift(viewer, tracks_viewer):
+    """The displayed dimensions of dims.point shift too, so the orthogonal views
+    (which slice on x and y) follow the reference track as well."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+
+    # the track moves [-30, 0, 30] in z, y, x between t=0 and t=1
+    assert tuple(viewer.dims.point) == (1, 20, 50, 80)
+
+
+def test_each_step_shifts_on_its_own(viewer, tracks_viewer):
+    """Stepping forward and straight back leaves the view where it started."""
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    viewer.dims.set_current_step(0, 1)
+    viewer.dims.set_current_step(0, 0)
+
+    assert tuple(viewer.dims.point) == (0, 50, 50, 50)
+
+
+def test_orthogonal_views_follow_the_reference_track(
+    viewer, solution_tracks_3d_with_division, qtbot
+):
+    """Every view follows, including the one whose own time slider was moved.
+
+    The orthogonal views block their sync while they drive it, so the view the user
+    moved would otherwise be the only one left behind.
+    """
+
+    ortho_manager = initialize_ortho_views(viewer)
+    ortho_manager.show()
+    qtbot.waitUntil(ortho_manager.is_shown, timeout=1000)
+
+    tracks_viewer = TracksViewer.get_instance(viewer)
+    tracks_viewer.update_tracks(tracks=solution_tracks_3d_with_division, name="test")
+    qtbot.wait(50)
+
+    right_vm = ortho_manager.right_widget.vm_container.viewer_model
+    bottom_vm = ortho_manager.bottom_widget.vm_container.viewer_model
+
+    tracks_viewer.set_reference_track(1)
+    viewer.dims.point = (0, 50, 50, 50)
+    qtbot.wait(50)
+
+    # move time on the right orthogonal view, the way the user would
+    right_vm.dims.set_current_step(0, 1)
+    qtbot.wait(50)
+
+    # the track moves [-30, 0, 30] in z, y, x between t=0 and t=1
+    expected = (1, 20, 50, 80)
+    assert tuple(viewer.dims.point) == expected
+    assert tuple(right_vm.dims.point) == expected
+    assert tuple(bottom_vm.dims.point) == expected
+
+    ortho_manager.cleanup()
+
+
+def test_edits_to_the_reference_track_are_picked_up(viewer, tracks_viewer):
+    """The two nodes are looked up fresh, so moving one changes the next shift."""
+
+    tracks_viewer.set_reference_track(1)
+    # node 2 is the t=1 node of track 1, at [20, 50, 80]
+    tracks_viewer.tracks.set_position(2, [10, 50, 90])
+
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+
+    assert tuple(viewer.dims.point) == (1, 10, 50, 90)  # 50 + (10 - 50), etc.
+
+
+def test_clearing_the_reference_track(viewer, tracks_viewer):
+    """Clearing the reference stops the view from following it."""
+
+    tracks_viewer.set_reference_track(1)
+    tracks_viewer.set_reference_track(None)
+    viewer.dims.point = (0, 50, 50, 50)
+    _step_to(viewer, 1)
+
+    assert tracks_viewer.reference_track is None
+    assert viewer.dims.point[1] == 50
+
+
+def test_unknown_track_id_is_rejected(tracks_viewer):
+    """A track id that is not in the tracks does not become the reference."""
+
+    tracks_viewer.set_reference_track(999)
+
+    assert tracks_viewer.reference_track is None
+
+
+def test_reference_track_widget(viewer, tracks_viewer, qtbot):
+    """The button toggles the active tracklet id and shows it in its color."""
+
+    widget = VisualizationWidget(viewer)
+    qtbot.addWidget(widget)
+    button = widget.reference_track_widget.reference_btn
+
+    tracks_viewer.selected_nodes.add(1)  # track id 1
+    button.click()
+
+    assert tracks_viewer.reference_track == 1
+    assert button.text() == "Reference: 1"
+    assert "border" in button.styleSheet()
+
+    # clicking again with the same tracklet active clears the reference
+    button.click()
+
+    assert tracks_viewer.reference_track is None
+    assert button.text() == "Reference: None"
+    assert "rgba(0,0,0,0)" in button.styleSheet()
+
+
+def test_reference_track_widget_switches_track(viewer, tracks_viewer, qtbot):
+    """Clicking with a different tracklet active moves the reference to that one."""
+
+    widget = VisualizationWidget(viewer)
+    qtbot.addWidget(widget)
+    button = widget.reference_track_widget.reference_btn
+
+    tracks_viewer.selected_nodes.add(1)  # track id 1
+    button.click()
+    tracks_viewer.selected_nodes.add(3)  # a daughter, so a different track id
+    button.click()
+
+    assert tracks_viewer.reference_track == tracks_viewer.selected_track
+    assert tracks_viewer.reference_track != 1


### PR DESCRIPTION
An object's translation consists of its own intrinsic movement and the movement of the global object it belongs to (e.g. the full embryo). If the embryo suddenly changes its shape (e.g. it contracts or deflates), all objects are shifted. When correcting the tracks, this is annoying because you have to find your reference point back every time (and my brain cannot cache the pattern well so I keep scrolling back and forth to compare). However, once one tracklet is defined, it could serve as a reference, so that when you move to the next time point, the z, y, x, sliders are changing too according to the shift of that reference object. Of course this is only useful if the global shift is much larger than the intrinsic shift, so it depends on your use case. We typically do rigid registration across time before we start tracking, but that cannot correct for deflation events, so in such case changing the dims according to a reference could be helpful.

This PR adds a 'set reference tracklet' button to the visualization tab: when clicked, the currently active tracklet is set as reference and when moving the slider in time, the other sliders will move according to the reference object's shift, if it is available at those time points. Other dims changing events (e.g. centering on a node when clicking) are unaffected by this.


<img width="1000" height="710" alt="reference_tracklet" src="https://github.com/user-attachments/assets/65bbe7e2-0331-4d13-9ba3-0abf54382ede" />

Needs funtracks PR https://github.com/funkelab/funtracks/pull/281
