### PR TITLE
Unpin funtracks and fix CI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,6 +42,15 @@ jobs:
                      /etc/apt/sources.list.d/azure-cli.sources
       - uses: tlambert03/setup-qt-libs@v1
 
+      # wgpu (via pygfx/fastplotlib, used by the tree view) needs a real Vulkan/GL
+      # adapter; Xvfb (below) only provides X11/GLX, not Vulkan. lavapipe/llvmpipe
+      # give it a software one, matching how pygfx/wgpu-py run their own Linux CI.
+      - name: Install llvmpipe and lavapipe for offscreen wgpu rendering
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+
       - name: Set up Python
         uses: astral-sh/setup-uv@v7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,15 @@ jobs:
                      /etc/apt/sources.list.d/azure-cli.sources
       - uses: tlambert03/setup-qt-libs@v1
 
+      # wgpu (via pygfx/fastplotlib, used by the tree view) needs a real Vulkan/GL
+      # adapter; Xvfb (below) only provides X11/GLX, not Vulkan. lavapipe/llvmpipe
+      # give it a software one, matching how pygfx/wgpu-py run their own Linux CI.
+      - name: Install llvmpipe and lavapipe for offscreen wgpu rendering
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: astral-sh/setup-uv@v7
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,15 +105,6 @@ dev = [
 ]
 # For gurobi, install separately: uv pip install "gurobipy>=12,<13"
 
-[tool.uv.sources]
-# Unreleased funtracks, for tracksdata >= 0.1.0rc9: that release swapped spatial-graph
-# for rstar-python. spatial-graph's prebuilt rtree is a Cython limited-API build that
-# collides with pygfx's uharfbuzz over the shared _cython_3_3_0limitednofinalize module
-# ("Shared Cython type cython_function_or_method has the wrong size"), which broke GEFF
-# import in the tree view. rstar-python is Rust, so there is nothing to collide with.
-# Drop this source once a funtracks release includes the commit.
-funtracks = { git = "https://github.com/funkelab/funtracks.git", rev = "d9d83ea23c273e880b5b82cdc8343235d8e9e9eb" }
-
 [tool.uv]
 # gurobi12 and gurobi13 conflict with each other (mutually exclusive version pins)
 conflicts = [

--- a/tests/application_menus/test_feature_widget.py
+++ b/tests/application_menus/test_feature_widget.py
@@ -44,7 +44,9 @@ def feature_widget_factory(make_napari_viewer, request):
 def test_feature_display_names(feature_widget_factory, expected_names):
     widget, _ = feature_widget_factory
     checkbox_names = {cb.text() for cb in widget._checkboxes.values()}
-    assert checkbox_names == expected_names
+    # Subset check rather than equality: new regionprops features (e.g. intensity)
+    # may be registered by funtracks without this test needing to track every one.
+    assert expected_names <= checkbox_names
 
 
 def test_3d_names_only(make_napari_viewer, solution_tracks_3d):

--- a/tests/application_menus/test_main_app.py
+++ b/tests/application_menus/test_main_app.py
@@ -1,8 +1,5 @@
 """Tests for main_app.py: StartupWidget, MainAppWidget, and single menu widget classes."""
 
-import sys
-
-import pytest
 from qtpy.QtWidgets import QWidget
 
 from motile_tracker.application_menus.main_app import (
@@ -19,15 +16,6 @@ from motile_tracker.application_menus.main_app import (
     TrackingGroupWidget,
     TrackList_LauncherWidget,
     Visualization_LauncherWidget,
-)
-
-# MainAppWidget builds the fastplotlib/wgpu tree view. On headless Linux CI wgpu
-# aborts (SIGABRT) constructing the Qt canvas figure, killing the whole pytest
-# process. These are covered on macOS (Metal) and Windows (DX12); skip on Linux.
-# TODO: check in the future if headless Linux CI support can be added
-pytestmark = pytest.mark.skipif(
-    sys.platform == "linux",
-    reason="fastplotlib/wgpu can't build a Qt canvas on headless Linux CI",
 )
 
 

--- a/tests/application_menus/test_menu_manager.py
+++ b/tests/application_menus/test_menu_manager.py
@@ -1,22 +1,11 @@
 """Tests for MenuManager: initialization, tab management, and widget visibility."""
 
-import sys
 from unittest.mock import MagicMock
 
-import pytest
 from qtpy.QtWidgets import QDockWidget, QScrollArea, QTabBar, QWidget
 
 from motile_tracker.application_menus.main_app import MENU_WIDGETS, StartupWidget
 from motile_tracker.application_menus.menu_manager import MenuManager
-
-# Some MenuManager tests build the full app (StartupWidget/initialize_menu), which
-# constructs the fastplotlib/wgpu tree view. On headless Linux CI wgpu aborts
-# (SIGABRT) building the Qt canvas figure, killing the whole pytest process.
-# Covered on macOS (Metal) and Windows (DX12); skip on Linux.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "linux",
-    reason="fastplotlib/wgpu can't build a Qt canvas on headless Linux CI",
-)
 
 
 class DummyWidget(QWidget):

--- a/tests/benchmarks/bench_ui_actions.py
+++ b/tests/benchmarks/bench_ui_actions.py
@@ -15,18 +15,7 @@ under the ``offscreen`` Qt platform, which lacks a real GL context.
 
 from __future__ import annotations
 
-import sys
-
-import pytest
 from synthetic_data import pick_nodes, tracklet_nodes
-
-# These UI benchmarks build the fastplotlib/wgpu tree view, which aborts (SIGABRT) on
-# headless Linux CI (no usable GPU adapter for the Qt canvas). Run on macOS (Metal) and
-# Windows (DX12); skip on Linux — same as the tree-view tests in tests/data_views.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "linux",
-    reason="fastplotlib/wgpu can't build a Qt canvas on headless Linux CI",
-)
 
 # Rounds pytest-benchmark collects per measurement. The report gates on the *median*
 # across rounds, so >=3 rounds lets a single transient spike be ignored (see

--- a/tests/data_views/views/tree_view/test_tree_widget.py
+++ b/tests/data_views/views/tree_view/test_tree_widget.py
@@ -5,7 +5,6 @@ mode switching, and integration with TracksViewer.
 """
 
 import gc
-import sys
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -18,14 +17,6 @@ from motile_tracker.data_views.views.tree_view.navigation_widget import (
 )
 from motile_tracker.data_views.views.tree_view.tree_widget import TreeWidget
 from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
-
-# TreeWidget builds the fastplotlib/wgpu tree canvas. On headless Linux CI wgpu
-# aborts (SIGABRT) constructing the Qt canvas figure, killing the whole pytest
-# process. These are covered on macOS (Metal) and Windows (DX12); skip on Linux.
-pytestmark = pytest.mark.skipif(
-    sys.platform == "linux",
-    reason="fastplotlib/wgpu can't build a Qt canvas on headless Linux CI",
-)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
@TeunHuijben Didn't realize this made it into main, but it's obsolete now that funtracks 2.1.0 is released and pins tracksdata >=0.1.0rc9. Gonna merge without review to unblock some other things :)