### PR TITLE
Reconcile viewer and tracks dims

### DIFF
--- a/src/motile_tracker/data_views/dims_utils.py
+++ b/src/motile_tracker/data_views/dims_utils.py
@@ -1,0 +1,173 @@
+"""Relating the axes of a Tracks object to the axes of the napari viewer.
+
+The viewer can have more dimensions than the tracks do, e.g. because of multi-channel
+images being present in the same viewer as the tracks layers. Napari aligns every layer
+on its trailing dimensions, so the tracks occupy the last ``ndim_tracks`` world axes of
+the viewer. All additional leading dimensions are for visualization only.
+
+``dims.order`` only permutes how axes are *displayed*. ``dims.point``,
+``dims.current_step`` and ``dims.range`` stay indexed by world axis, and``roll()`` and
+``transpose()`` touch nothing but ``order``. So rolling or transposing with the napari
+buttons never moves an axis from one world index to another, and the map between tracks
+axes and world axes does not have to be remembered across a roll. A roll can put an extra
+axis on screen, so any code reading a displayed axis has to ask whether it is a tracks
+axis at all before using it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+
+def world_to_layer_axis(
+    world_axis: int, ndim_world: int, ndim_layer: int
+) -> int | None:
+    """Map a viewer (world) axis onto a layer's own axis, or None if it has none.
+
+    A layer with fewer dimensions than the viewer has no axis at all corresponding to the
+    leading world axes, and subtracting the offset there gives a negative index
+    that numpy would silently wrap to the wrong end of the array instead of raising.
+
+    Args:
+        world_axis (int): Axis index in the viewer's world coordinate system.
+        ndim_world (int): Number of dimensions of the viewer.
+        ndim_layer (int): Number of dimensions of the layer.
+
+    Returns:
+        int | None: The corresponding layer axis, or None if the layer does not
+            span this world axis.
+    """
+
+    layer_axis = world_axis - (ndim_world - ndim_layer)
+    if layer_axis < 0 or layer_axis >= ndim_layer:
+        return None
+    return layer_axis
+
+
+@dataclass(frozen=True)
+class TracksDims:
+    """Where a Tracks object's axes sit among the viewer's world axes.
+
+    The tracks take the last ``ndim_tracks`` world axes; ``offset`` counts the
+    extra ones in front. Meant to be built at the point of use rather than stored,
+    because ``ndim_world`` changes when layers are added or removed.
+
+    To know where a layer sits with respect to the viewer, use layer.ndim as ndim_world.
+
+    Attributes:
+        ndim_world (int): Number of dimensions of the viewer (or of the layer the
+            tracks are being related to).
+        ndim_tracks (int): Number of dimensions of the tracks, time included.
+    """
+
+    ndim_world: int
+    ndim_tracks: int
+
+    def __post_init__(self) -> None:
+        if self.ndim_tracks < 2:
+            raise ValueError(
+                f"Tracks must have at least a time and one spatial axis, got "
+                f"{self.ndim_tracks}"
+            )
+        if self.ndim_world < self.ndim_tracks:
+            raise ValueError(
+                f"The viewer has fewer dimensions ({self.ndim_world}) than the "
+                f"tracks ({self.ndim_tracks}); the tracks cannot be shown in it"
+            )
+
+    @property
+    def offset(self) -> int:
+        """Number of extra world axes in front of the tracks' own axes."""
+
+        return self.ndim_world - self.ndim_tracks
+
+    @property
+    def extra_axes(self) -> tuple[int, ...]:
+        """World axes that are not tracks axes, for visualization only."""
+
+        return tuple(range(self.offset))
+
+    @property
+    def world_axes(self) -> tuple[int, ...]:
+        """World axes the tracks span, in tracks order (time first)."""
+
+        return tuple(range(self.offset, self.ndim_world))
+
+    @property
+    def time_axis(self) -> int:
+        """World axis carrying time, which is the tracks' first axis."""
+
+        return self.offset
+
+    @property
+    def spatial_axes(self) -> tuple[int, ...]:
+        """World axes carrying the spatial dimensions ((z,) y, x)."""
+
+        return tuple(range(self.offset + 1, self.ndim_world))
+
+    def is_tracks_axis(self, world_axis: int) -> bool:
+        """Whether a world axis is one of the tracks' own axes."""
+
+        return self.offset <= world_axis < self.ndim_world
+
+    def to_world(self, tracks_axis: int) -> int:
+        """World axis for a tracks axis (0 being time).
+
+        Raises:
+            IndexError: If ``tracks_axis`` is not an axis of the tracks.
+        """
+
+        if not 0 <= tracks_axis < self.ndim_tracks:
+            raise IndexError(
+                f"Tracks axis {tracks_axis} out of range for "
+                f"{self.ndim_tracks}-dimensional tracks"
+            )
+        return tracks_axis + self.offset
+
+    def to_tracks(self, world_axis: int) -> int | None:
+        """Tracks axis for a world axis, or None if it is an extra axis."""
+
+        return world_to_layer_axis(world_axis, self.ndim_world, self.ndim_tracks)
+
+    def embed_point(
+        self, location: Sequence[float], point: Sequence[float]
+    ) -> list[float]:
+        """Write a tracks-space location into a full-length viewer point.
+
+        The extra leading axes keep whatever the viewer is currently showing, only the
+        trailing tracks axes are replaced.
+
+        Args:
+            location (Sequence[float]): Position in tracks space, time included.
+            point (Sequence[float]): The viewer's current ``dims.point``.
+
+        Returns:
+            list[float]: A point of length ``ndim_world``, ready to assign to
+                ``viewer.dims.point``.
+        """
+
+        if len(location) != self.ndim_tracks:
+            raise ValueError(
+                f"Location {tuple(location)} has {len(location)} dimensions, "
+                f"expected {self.ndim_tracks}"
+            )
+        if len(point) != self.ndim_world:
+            raise ValueError(
+                f"Point has {len(point)} dimensions, expected {self.ndim_world}"
+            )
+
+        embedded = list(point)
+        embedded[self.offset :] = list(location)
+        return embedded
+
+    def take(self, values: Sequence) -> tuple:
+        """The tracks-axis part of a world-indexed sequence.
+
+        For pulling the tracks' own values out of ``dims.point``,
+        ``dims.current_step``, ``dims.range`` etc.
+        """
+
+        if len(values) != self.ndim_world:
+            raise ValueError(f"Expected {self.ndim_world} values, got {len(values)}")
+        return tuple(values[self.offset :])

--- a/src/motile_tracker/data_views/views/layers/track_labels.py
+++ b/src/motile_tracker/data_views/views/layers/track_labels.py
@@ -433,7 +433,11 @@ class TrackLabels(ContourLabels):
 
         update_colormap = False
         if self.tracks_viewer.tracks is not None:
-            current_timepoint = self.viewer.dims.current_step[0]
+            # The viewer may carry extra leading axes the tracks do not have, so time is
+            # not necessarily axis 0.
+            current_timepoint = self.viewer.dims.current_step[
+                self.tracks_viewer.tracks_dims.time_axis
+            ]
             # if a node with the given label is already in the graph
             if self.tracks_viewer.tracks.graph.has_node(self.selected_label):
                 # Update the track id

--- a/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
+++ b/src/motile_tracker/data_views/views/layers/tracks_layer_group.py
@@ -6,6 +6,7 @@ import napari
 from funtracks.data_model import Tracks
 from napari.experimental import link_layers, unlink_layers
 
+from motile_tracker.data_views.dims_utils import TracksDims, world_to_layer_axis
 from motile_tracker.data_views.views.layers.track_graph import TrackGraph
 from motile_tracker.data_views.views.layers.track_labels import TrackLabels
 from motile_tracker.data_views.views.layers.track_points import TrackPoints
@@ -140,59 +141,80 @@ class TracksLayerGroup:
         """Adjust the current_step and camera center of the viewer to jump to the node
         location, if the node is not already in the field of view"""
 
-        if self.seg_layer is None or self.seg_layer.mode == "pan_zoom":
-            location = self.tracks.get_position(node, incl_time=True)
-            assert len(location) == self.viewer.dims.ndim, (
-                f"Location {location} does not match viewer number of dims "
-                f"{self.viewer.dims.ndim}"
+        if self.seg_layer is not None and self.seg_layer.mode != "pan_zoom":
+            return
+
+        # The viewer may carry more dimensions than the tracks do. The tracks own the
+        # trailing axes.
+        dims = TracksDims(self.viewer.dims.ndim, self.tracks.ndim)
+
+        location = self.tracks.get_position(node, incl_time=True)
+        if len(location) != dims.ndim_tracks:
+            raise ValueError(
+                f"Location {location} does not match the number of dimensions of the "
+                f"tracks ({dims.ndim_tracks})"
             )
 
-            # Set dims.point directly with world coordinates - napari will
-            # automatically convert to the correct step indices
-            self.viewer.dims.point = location
+        # Retrieve the tracks point in the viewer dimensions.
+        # Set dims.point directly with world coordinates, napari will convert the step
+        # indices. Extra leading axes keep their current position.
+        point = dims.embed_point(location, self.viewer.dims.point)
+        self.viewer.dims.point = point
 
-            # check whether the new coordinates are inside or outside the field of view,
-            # then adjust the camera if needed
-            example_layer = (
-                self.points_layer
-            )  # the points layer is always in world units,
-            # because it directly reads the scaled coordinates. Therefore, no rescaling
-            # is necessary to compute the camera center
-            corner_coordinates = example_layer.corner_pixels
+        # check whether the new coordinates are inside or outside the field of view,
+        # then adjust the camera if needed. The points layer is always in world units,
+        # because it directly reads the scaled coordinates. Therefore, no rescaling
+        # is necessary to compute the camera center.
+        example_layer = self.points_layer
+        corner_coordinates = example_layer.corner_pixels
 
-            # check which dimensions are shown, the first dimension is displayed on the
-            # x axis, and the second on the y_axis
-            dims_displayed = self.viewer.dims.displayed
+        # check which dimensions are shown, the first dimension is displayed on the
+        # x axis, and the second on the y_axis
+        dims_displayed = self.viewer.dims.displayed
 
-            # Note: This centering does not work in 3D. What we should do instead is take
-            # the view direction vector, start at the point, and move backward along the
-            # vector a certain amount to put the point in view.
-            # Note #2: Points already does centering when you add the first point, and it
-            # works in 3D. We can look at that to see what logic they use.
+        # Note: This centering does not work in 3D. What we should do instead is take
+        # the view direction vector, start at the point, and move backward along the
+        # vector a certain amount to put the point in view.
+        # Note #2: Points already does centering when you add the first point, and it
+        # works in 3D. We can look at that to see what logic they use.
 
-            # self.viewer.dims.displayed_order
-            x_dim = dims_displayed[-1]
-            y_dim = dims_displayed[-2]
+        # self.viewer.dims.displayed_order
+        x_dim = dims_displayed[-1]
+        y_dim = dims_displayed[-2]
 
-            # find corner pixels for the displayed axes
-            _min_x = corner_coordinates[0][x_dim]
-            _max_x = corner_coordinates[1][x_dim]
-            _min_y = corner_coordinates[0][y_dim]
-            _max_y = corner_coordinates[1][y_dim]
+        # corner_pixels is indexed by the layer's own axes, while dims_displayed indexes
+        # the viewer's, so the displayed axes have to be translated. Rolling or
+        # transposing with the napari buttons can put an axis the points layer does not
+        # span (a channel, say) on screen; centering on one is meaningless, so leave the
+        # camera alone rather than indexing corner_pixels out of bounds.
+        x_layer_dim = world_to_layer_axis(
+            x_dim, self.viewer.dims.ndim, example_layer.ndim
+        )
+        y_layer_dim = world_to_layer_axis(
+            y_dim, self.viewer.dims.ndim, example_layer.ndim
+        )
+        if x_layer_dim is None or y_layer_dim is None:
+            return
 
-            # check whether the node location falls within the corner spatial range
-            if not (
-                (location[x_dim] > _min_x and location[x_dim] < _max_x)
-                and (location[y_dim] > _min_y and location[y_dim] < _max_y)
-            ):
-                camera_center = self.viewer.camera.center
+        # find corner pixels for the displayed axes
+        _min_x = corner_coordinates[0][x_layer_dim]
+        _max_x = corner_coordinates[1][x_layer_dim]
+        _min_y = corner_coordinates[0][y_layer_dim]
+        _max_y = corner_coordinates[1][y_layer_dim]
 
-                # set the center y and x to the center of the node, by using the index
-                # of the currently displayed dimensions
-                self.viewer.camera.center = (
-                    camera_center[0],
-                    location[y_dim],
-                    # camera center is calculated in scaled coordinates, and the optional
-                    # labels layer is scaled by the layer.scale attribute
-                    location[x_dim],
-                )
+        # check whether the node location falls within the corner spatial range
+        if not (
+            (point[x_dim] > _min_x and point[x_dim] < _max_x)
+            and (point[y_dim] > _min_y and point[y_dim] < _max_y)
+        ):
+            camera_center = self.viewer.camera.center
+
+            # set the center y and x to the center of the node, by using the index
+            # of the currently displayed dimensions
+            self.viewer.camera.center = (
+                camera_center[0],
+                point[y_dim],
+                # camera center is calculated in scaled coordinates, and the optional
+                # labels layer is scaled by the layer.scale attribute
+                point[x_dim],
+            )

--- a/src/motile_tracker/data_views/views/ortho_views.py
+++ b/src/motile_tracker/data_views/views/ortho_views.py
@@ -241,7 +241,7 @@ def paint_event_hook(
     def sync_paint(orig_layer: TrackLabels, copied_layer: Labels, event: Event):
         """Process paint event on original TrackLabels instance."""
 
-        if copied_layer.data.ndim > 3:
+        if orig_layer.tracks_viewer.tracks.ndim > 3:
             orig_layer._on_paint(event)
         else:
             show_info("Painting in the time dimension is not supported")

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -136,6 +136,18 @@ class TracksViewer:
             raise RuntimeError("No tracks are loaded, so they have no dimensions")
         return TracksDims(self.viewer.dims.ndim, self.tracks.ndim)
 
+    def set_axis_labels(self) -> None:
+        """Name the viewer's sliders after the axes the tracks use."""
+
+        if self.tracks is None:
+            return
+
+        dims = self.tracks_dims
+        labels = list(self.viewer.dims.axis_labels)
+        # any 'extra' dims just keep the name they had already
+        labels[dims.offset :] = ["t", *self.tracks.axis_names]
+        self.viewer.dims.axis_labels = labels
+
     def get_collection_widget(self) -> CollectionWidget:
         """Return a reference to the groups widget"""
         if self.collection_widget is None or getattr(
@@ -315,6 +327,7 @@ class TracksViewer:
 
         self.set_display_mode("all")
         self.tracking_layers.set_tracks(tracks, name)
+        self.set_axis_labels()  # the layers are in, so the viewer's dims have settled
         self.selected_nodes.reset()
 
         # ensure a valid track is selected from the start

--- a/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
+++ b/src/motile_tracker/data_views/views_coordinator/tracks_viewer.py
@@ -16,6 +16,7 @@ from funtracks.user_actions import (
 from psygnal import Signal
 from qtpy.QtWidgets import QMessageBox
 
+from motile_tracker.data_views.dims_utils import TracksDims
 from motile_tracker.data_views.keybindings_config import (
     KEYMAP,
     bind_keymap,
@@ -122,6 +123,18 @@ class TracksViewer:
         self.set_keybinds()
 
         self.viewer.dims.events.ndisplay.connect(self.update_selection)
+
+    @property
+    def tracks_dims(self) -> TracksDims:
+        """How the tracks' axes sit compared to the viewer's world axes.
+
+        Raises:
+            RuntimeError: If no tracks are loaded.
+        """
+
+        if self.tracks is None:
+            raise RuntimeError("No tracks are loaded, so they have no dimensions")
+        return TracksDims(self.viewer.dims.ndim, self.tracks.ndim)
 
     def get_collection_widget(self) -> CollectionWidget:
         """Return a reference to the groups widget"""

--- a/src/motile_tracker/motile/menus/run_editor.py
+++ b/src/motile_tracker/motile/menus/run_editor.py
@@ -88,7 +88,12 @@ class RunEditor(QGroupBox):
 
     def _update_max_frames(self) -> None:
         """Update the max frame constraint from viewer dims."""
-        max_frame = self.viewer.dims.range[0].stop
+
+        # Obtain the time axis from the layer, not the viewer (since it may carry extra
+        # dims)
+        layer = self.get_input_layer()
+        time_axis = 0 if layer is None else self.viewer.dims.ndim - layer.ndim
+        max_frame = self.viewer.dims.range[time_axis].stop
         self.solver_params_widget.set_max_frames(int(max_frame))
 
     def _labels_layer_widget(self) -> QWidget:

--- a/tests/data_views/test_axis_labels.py
+++ b/tests/data_views/test_axis_labels.py
@@ -1,0 +1,112 @@
+import numpy as np
+import tracksdata as td
+from funtracks.data_model import SolutionTracks
+from funtracks.utils.tracksdata_utils import create_empty_graphview_graph
+from tracksdata.nodes._mask import Mask
+
+from motile_tracker.data_views.views_coordinator.tracks_viewer import TracksViewer
+
+
+def _make_single_node_graph(
+    tmp_path,
+    pos: list,
+    seg_bbox: list | None = None,
+    seg_shape: tuple | None = None,
+) -> td.graph.GraphView:
+    """Create a 3D+time tracksdata graph with a single node at the given position.
+
+    Args:
+        tmp_path: Pytest tmp_path for the SQLite database.
+        pos: Node position in world coordinates [z, y, x].
+        seg_bbox: Bounding box [z0, y0, x0, z1, y1, x1] for the node's mask.
+            If provided, mask/bbox node attributes and shape metadata
+            are added so SolutionTracks can reconstruct the segmentation.
+        seg_shape: Full segmentation array shape (t, z, y, x). Required when
+            seg_bbox is provided.
+    """
+    node_attributes = ["pos", "area"]
+    if seg_bbox is not None:
+        node_attributes += [td.DEFAULT_ATTR_KEYS.MASK, td.DEFAULT_ATTR_KEYS.BBOX]
+
+    graph = create_empty_graphview_graph(
+        node_attributes=node_attributes,
+        ndim=4,
+        database=str(tmp_path / "graph.db"),
+    )
+
+    node: dict = {"t": 0, "pos": list(pos), "area": 1000.0, "solution": True}
+    if seg_bbox is not None:
+        bbox = np.array(seg_bbox, dtype=np.int64)
+        mask_shape = tuple(int(bbox[i + 3] - bbox[i]) for i in range(3))
+        node[td.DEFAULT_ATTR_KEYS.MASK] = Mask(
+            np.ones(mask_shape, dtype=bool), bbox=bbox
+        )
+        node[td.DEFAULT_ATTR_KEYS.BBOX] = bbox
+
+    graph.bulk_add_nodes(nodes=[node], indices=[1])
+
+    if seg_shape is not None:
+        graph._update_metadata(shape=seg_shape)
+
+    return graph
+
+
+class TestAxisLabels:
+    """The tracks name the sliders they own.
+
+    napari shows dims.axis_labels on the dim sliders, and they are indexed by world
+    axis, so the tracks' names go on the trailing axes they occupy and any extra
+    leading axis keeps its own label.
+    """
+
+    def _tracks_3d(self, tmp_path):
+        graph = _make_single_node_graph(
+            tmp_path,
+            pos=[5, 10, 10],
+            seg_bbox=[4, 9, 9, 6, 11, 11],
+            seg_shape=(2, 20, 20, 20),
+        )
+        return SolutionTracks(
+            graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
+        )
+
+    def test_tracks_name_their_own_axes_only(self, viewer, tmp_path):
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=self._tracks_3d(tmp_path), name="test")
+
+        assert tuple(viewer.dims.axis_labels) == ("t", "z", "y", "x")
+
+        # a channel layer arriving later widens the viewer; napari prepends, so the
+        # names stay on the tracks' own axes and the new one keeps its own label
+        viewer.add_image(np.zeros((3, 2, 20, 20, 20), dtype=np.uint8), name="chan")
+        viewer.dims.set_axis_label(0, "channel")
+
+        dims = tracks_viewer.tracks_dims
+        labels = viewer.dims.axis_labels
+        assert tuple(labels) == ("channel", "t", "z", "y", "x")
+        # the labelling and the axis map agree, or a slider would say one thing
+        # while centering did another
+        assert labels[dims.time_axis] == "t"
+        assert tuple(labels[axis] for axis in dims.spatial_axes) == ("z", "y", "x")
+
+    def test_2d_tracks_are_labelled_without_a_z(self, viewer, tmp_path):
+        """The old hardcoded suffix gave 2D+time tracks ('z','y','x'), naming the
+        time axis 'z'."""
+
+        graph = create_empty_graphview_graph(
+            node_attributes=["pos", "area"],
+            ndim=3,
+            database=str(tmp_path / "graph2d.db"),
+        )
+        graph.bulk_add_nodes(
+            nodes=[{"t": 0, "pos": [10, 10], "area": 100.0, "solution": True}],
+            indices=[1],
+        )
+        tracks = SolutionTracks(
+            graph=graph, scale=[1.0, 1.0, 1.0], ndim=3, time_attr="t"
+        )
+
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+
+        assert tuple(viewer.dims.axis_labels) == ("t", "y", "x")

--- a/tests/data_views/test_center_view.py
+++ b/tests/data_views/test_center_view.py
@@ -393,3 +393,252 @@ class TestCenterViewWithScale:
         )
 
         ortho_manager.cleanup()
+
+
+class TestCenterViewWithExtraViewerDims:
+    """The viewer may carry more dimensions than the tracks do.
+
+    A multi-channel intensity layer adds an axis in front of the ones the tracks
+    use. napari aligns layers on their trailing dimensions, so the tracks own the
+    last `tracks.ndim` world axes and the extra leading ones are for
+    visualization only.
+    """
+
+    def _tracks_with_channel_layer(self, viewer, tmp_path, n_channels=3):
+        """3D+time tracks in a viewer that also holds a multi-channel image."""
+
+        graph = _make_single_node_graph(
+            tmp_path,
+            pos=[5, 10, 10],
+            seg_bbox=[4, 9, 9, 6, 11, 11],
+            seg_shape=(2, 20, 20, 20),
+        )
+        tracks = SolutionTracks(
+            graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
+        )
+
+        # (c, t, z, y, x): one axis more than the tracks have
+        viewer.add_image(
+            np.zeros((n_channels, 2, 20, 20, 20), dtype=np.uint8), name="channels"
+        )
+
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+        return tracks_viewer
+
+    def test_center_view_does_not_crash_with_an_extra_dimension(self, viewer, tmp_path):
+        """The reported bug: selecting a node raised an AssertionError because the
+        node location had fewer entries than the viewer had dims."""
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        assert viewer.dims.ndim == 5
+        assert tracks_viewer.tracks.ndim == 4
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        # the tracks axes hold the node position, time first
+        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+
+    def test_the_extra_axis_keeps_its_slider_position(self, viewer, tmp_path):
+        """Jumping to a node must not move the user off the channel they are
+        looking at."""
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        point = list(viewer.dims.point)
+        point[0] = 2.0  # user picked channel 2
+        viewer.dims.point = point
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        assert viewer.dims.point[0] == 2.0
+
+    def test_the_point_is_visible_after_centering(self, viewer, tmp_path):
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        points_layer = tracks_viewer.tracking_layers.points_layer
+        node_index = points_layer.node_index_dict[1]
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        assert node_index in points_layer._indices_view
+
+    def test_selecting_a_node_through_the_signal_does_not_crash(self, viewer, tmp_path):
+        """The crash arrived through the center_node signal, whose callbacks
+        swallow the traceback into a napari warning."""
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+
+        tracks_viewer.center_node.emit(1)
+
+        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+
+    @pytest.mark.parametrize("n_rolls", [1, 2, 3])
+    def test_center_view_survives_a_roll(self, viewer, tmp_path, n_rolls):
+        """Rolling the dim order must not corrupt centering.
+
+        A roll only permutes `dims.order`; `dims.point` stays indexed by world
+        axis. But a roll can put the extra channel axis on screen, and centering
+        the camera on a channel is meaningless, so that case is skipped rather
+        than indexing the layer's corner_pixels out of bounds.
+        """
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        for _ in range(n_rolls):
+            viewer.dims.roll()
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        # the tracks axes still receive the node position, whatever the display order
+        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+
+    def test_camera_is_left_alone_when_a_non_tracks_axis_is_displayed(
+        self, viewer, tmp_path
+    ):
+        """With the channel axis on screen there is no sensible centering to do."""
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+
+        # find a display order that puts the channel axis (world 0) on screen
+        for _ in range(viewer.dims.ndim):
+            if 0 in viewer.dims.displayed:
+                break
+            viewer.dims.roll()
+        assert 0 in viewer.dims.displayed
+
+        camera_before = tuple(viewer.camera.center)
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        assert tuple(viewer.camera.center) == camera_before
+        # the dims point is still updated, only the camera is skipped
+        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+
+    def test_time_is_read_from_the_right_axis(self, viewer, tmp_path):
+        """TrackLabels reads the current time point from dims.current_step, which
+        is indexed by world axis, so it is not step 0 when a channel axis is
+        in front of it."""
+
+        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+
+        assert tracks_viewer.tracks_dims.time_axis == 1
+        assert tracks_viewer.tracks_dims.offset == 1
+        assert tracks_viewer.tracks_dims.extra_axes == (0,)
+
+    def test_two_extra_dimensions(self, viewer, tmp_path):
+        """Nothing about the design is specific to a single extra axis."""
+
+        graph = _make_single_node_graph(
+            tmp_path,
+            pos=[5, 10, 10],
+            seg_bbox=[4, 9, 9, 6, 11, 11],
+            seg_shape=(2, 20, 20, 20),
+        )
+        tracks = SolutionTracks(
+            graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
+        )
+        viewer.add_image(np.zeros((2, 3, 2, 20, 20, 20), dtype=np.uint8))
+
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+
+        assert viewer.dims.ndim == 6
+        assert tracks_viewer.tracks_dims.offset == 2
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+
+        assert tuple(viewer.dims.point[2:]) == (0, 5, 10, 10)
+
+
+class TestCenterViewOrthoViewsWithExtraDims:
+    """Centering has to reach the orthogonal views when the viewer carries more
+    dimensions than the tracks, and has to survive a roll of the dim order.
+
+    The ortho views sync on `dims.point`, which is indexed by world axis, so the
+    sync itself is dimension- and order-agnostic. These tests pin that.
+    """
+
+    def _setup(self, viewer, qtbot, tmp_path, extra_shape=None):
+        ortho_manager = initialize_ortho_views(viewer)
+        graph = _make_single_node_graph(
+            tmp_path,
+            pos=[5, 10, 10],
+            seg_bbox=[4, 9, 9, 6, 11, 11],
+            seg_shape=(2, 20, 20, 20),
+        )
+        tracks = SolutionTracks(
+            graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
+        )
+        ortho_manager.show()
+        qtbot.waitUntil(lambda: ortho_manager.is_shown(), timeout=2000)
+
+        tracks_viewer = TracksViewer.get_instance(viewer)
+        tracks_viewer.update_tracks(tracks=tracks, name="test")
+        qtbot.wait(50)
+
+        if extra_shape is not None:
+            viewer.add_image(np.zeros(extra_shape, dtype=np.uint8), name="channels")
+            qtbot.wait(50)
+
+        return ortho_manager, tracks_viewer
+
+    def test_centering_reaches_the_ortho_views_with_an_extra_dimension(
+        self, viewer, qtbot, tmp_path
+    ):
+        ortho_manager, tracks_viewer = self._setup(
+            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
+        )
+        assert viewer.dims.ndim == 5
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+        qtbot.wait(50)
+
+        right = ortho_manager.right_widget.vm_container.viewer_model
+        bottom = ortho_manager.bottom_widget.vm_container.viewer_model
+        expected = (0.0, 5.0, 10.0, 10.0)
+        assert tuple(viewer.dims.point[1:]) == expected
+        assert tuple(right.dims.point[1:]) == expected
+        assert tuple(bottom.dims.point[1:]) == expected
+
+        ortho_manager.cleanup()
+
+    def test_centering_reaches_the_ortho_views_after_a_roll(
+        self, viewer, qtbot, tmp_path
+    ):
+        """A roll permutes dims.order only, so the world-indexed point sync is
+        unaffected and the node still lands in every view."""
+
+        ortho_manager, tracks_viewer = self._setup(
+            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
+        )
+        viewer.dims.roll()
+        qtbot.wait(50)
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+        qtbot.wait(50)
+
+        right = ortho_manager.right_widget.vm_container.viewer_model
+        bottom = ortho_manager.bottom_widget.vm_container.viewer_model
+        expected = (0.0, 5.0, 10.0, 10.0)
+        assert tuple(viewer.dims.point[1:]) == expected
+        assert tuple(right.dims.point[1:]) == expected
+        assert tuple(bottom.dims.point[1:]) == expected
+
+        ortho_manager.cleanup()
+
+    def test_the_extra_axis_is_not_moved_by_the_ortho_sync(
+        self, viewer, qtbot, tmp_path
+    ):
+        ortho_manager, tracks_viewer = self._setup(
+            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
+        )
+        point = list(viewer.dims.point)
+        point[0] = 2.0
+        viewer.dims.point = point
+        qtbot.wait(50)
+
+        tracks_viewer.tracking_layers.center_view(node=1)
+        qtbot.wait(50)
+
+        right = ortho_manager.right_widget.vm_container.viewer_model
+        assert viewer.dims.point[0] == 2.0
+        assert right.dims.point[0] == 2.0
+
+        ortho_manager.cleanup()

--- a/tests/data_views/test_center_view.py
+++ b/tests/data_views/test_center_view.py
@@ -395,16 +395,16 @@ class TestCenterViewWithScale:
         ortho_manager.cleanup()
 
 
-class TestCenterViewWithExtraViewerDims:
+class TestExtraViewerDims:
     """The viewer may carry more dimensions than the tracks do.
 
     A multi-channel intensity layer adds an axis in front of the ones the tracks
     use. napari aligns layers on their trailing dimensions, so the tracks own the
-    last `tracks.ndim` world axes and the extra leading ones are for
-    visualization only.
+    last `tracks.ndim` world axes and the extra leading ones are for visualization
+    only.
     """
 
-    def _tracks_with_channel_layer(self, viewer, tmp_path, n_channels=3):
+    def _setup(self, viewer, tmp_path, extra_shape=(3, 2, 20, 20, 20)):
         """3D+time tracks in a viewer that also holds a multi-channel image."""
 
         graph = _make_single_node_graph(
@@ -416,146 +416,70 @@ class TestCenterViewWithExtraViewerDims:
         tracks = SolutionTracks(
             graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
         )
-
-        # (c, t, z, y, x): one axis more than the tracks have
-        viewer.add_image(
-            np.zeros((n_channels, 2, 20, 20, 20), dtype=np.uint8), name="channels"
-        )
+        if extra_shape is not None:
+            viewer.add_image(np.zeros(extra_shape, dtype=np.uint8), name="channels")
 
         tracks_viewer = TracksViewer.get_instance(viewer)
         tracks_viewer.update_tracks(tracks=tracks, name="test")
         return tracks_viewer
 
-    def test_center_view_does_not_crash_with_an_extra_dimension(self, viewer, tmp_path):
+    def test_centering_with_an_extra_dimension(self, viewer, tmp_path):
         """The reported bug: selecting a node raised an AssertionError because the
         node location had fewer entries than the viewer had dims."""
 
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        tracks_viewer = self._setup(viewer, tmp_path)
         assert viewer.dims.ndim == 5
         assert tracks_viewer.tracks.ndim == 4
+        assert tracks_viewer.tracks_dims.time_axis == 1
+        assert tracks_viewer.tracks_dims.extra_axes == (0,)
 
-        tracks_viewer.tracking_layers.center_view(node=1)
-
-        # the tracks axes hold the node position, time first
-        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
-
-    def test_the_extra_axis_keeps_its_slider_position(self, viewer, tmp_path):
-        """Jumping to a node must not move the user off the channel they are
-        looking at."""
-
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
+        # the user is looking at channel 2; centering must not move them off it
         point = list(viewer.dims.point)
-        point[0] = 2.0  # user picked channel 2
+        point[0] = 2.0
         viewer.dims.point = point
 
-        tracks_viewer.tracking_layers.center_view(node=1)
-
-        assert viewer.dims.point[0] == 2.0
-
-    def test_the_point_is_visible_after_centering(self, viewer, tmp_path):
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
-        points_layer = tracks_viewer.tracking_layers.points_layer
-        node_index = points_layer.node_index_dict[1]
-
-        tracks_viewer.tracking_layers.center_view(node=1)
-
-        assert node_index in points_layer._indices_view
-
-    def test_selecting_a_node_through_the_signal_does_not_crash(self, viewer, tmp_path):
-        """The crash arrived through the center_node signal, whose callbacks
-        swallow the traceback into a napari warning."""
-
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
-
+        # the crash arrived through the signal, whose callbacks wrap the traceback
         tracks_viewer.center_node.emit(1)
 
         assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+        assert viewer.dims.point[0] == 2.0
+        points_layer = tracks_viewer.tracking_layers.points_layer
+        assert points_layer.node_index_dict[1] in points_layer._indices_view
 
-    @pytest.mark.parametrize("n_rolls", [1, 2, 3])
-    def test_center_view_survives_a_roll(self, viewer, tmp_path, n_rolls):
-        """Rolling the dim order must not corrupt centering.
-
-        A roll only permutes `dims.order`; `dims.point` stays indexed by world
-        axis. But a roll can put the extra channel axis on screen, and centering
-        the camera on a channel is meaningless, so that case is skipped rather
-        than indexing the layer's corner_pixels out of bounds.
+    def test_centering_survives_a_roll(self, viewer, tmp_path):
+        """A roll leaves dims.point indexed by world axis, so the node still lands
+        on the tracks axes. But it can put the channel axis on screen, and centering
+        the camera on a channel is meaningless, so that is skipped rather than
+        indexing the points layer's corner_pixels out of bounds.
         """
 
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
-        for _ in range(n_rolls):
-            viewer.dims.roll()
+        tracks_viewer = self._setup(viewer, tmp_path)
+        saw_extra_axis_displayed = False
 
-        tracks_viewer.tracking_layers.center_view(node=1)
-
-        # the tracks axes still receive the node position, whatever the display order
-        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
-
-    def test_camera_is_left_alone_when_a_non_tracks_axis_is_displayed(
-        self, viewer, tmp_path
-    ):
-        """With the channel axis on screen there is no sensible centering to do."""
-
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
-
-        # find a display order that puts the channel axis (world 0) on screen
         for _ in range(viewer.dims.ndim):
-            if 0 in viewer.dims.displayed:
-                break
             viewer.dims.roll()
-        assert 0 in viewer.dims.displayed
+            camera_before = tuple(viewer.camera.center)
 
-        camera_before = tuple(viewer.camera.center)
-        tracks_viewer.tracking_layers.center_view(node=1)
+            tracks_viewer.tracking_layers.center_view(node=1)
 
-        assert tuple(viewer.camera.center) == camera_before
-        # the dims point is still updated, only the camera is skipped
-        assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+            # whatever the display order, the tracks axes receive the position
+            assert tuple(viewer.dims.point[1:]) == (0, 5, 10, 10)
+            if 0 in viewer.dims.displayed:
+                saw_extra_axis_displayed = True
+                assert tuple(viewer.camera.center) == camera_before
 
-    def test_time_is_read_from_the_right_axis(self, viewer, tmp_path):
-        """TrackLabels reads the current time point from dims.current_step, which
-        is indexed by world axis, so it is not step 0 when a channel axis is
-        in front of it."""
-
-        tracks_viewer = self._tracks_with_channel_layer(viewer, tmp_path)
-
-        assert tracks_viewer.tracks_dims.time_axis == 1
-        assert tracks_viewer.tracks_dims.offset == 1
-        assert tracks_viewer.tracks_dims.extra_axes == (0,)
-
-    def test_two_extra_dimensions(self, viewer, tmp_path):
-        """Nothing about the design is specific to a single extra axis."""
-
-        graph = _make_single_node_graph(
-            tmp_path,
-            pos=[5, 10, 10],
-            seg_bbox=[4, 9, 9, 6, 11, 11],
-            seg_shape=(2, 20, 20, 20),
-        )
-        tracks = SolutionTracks(
-            graph=graph, scale=[1.0, 1.0, 1.0, 1.0], ndim=4, time_attr="t"
-        )
-        viewer.add_image(np.zeros((2, 3, 2, 20, 20, 20), dtype=np.uint8))
-
-        tracks_viewer = TracksViewer.get_instance(viewer)
-        tracks_viewer.update_tracks(tracks=tracks, name="test")
-
-        assert viewer.dims.ndim == 6
-        assert tracks_viewer.tracks_dims.offset == 2
-
-        tracks_viewer.tracking_layers.center_view(node=1)
-
-        assert tuple(viewer.dims.point[2:]) == (0, 5, 10, 10)
+        assert saw_extra_axis_displayed, "a roll should display the channel axis"
 
 
-class TestCenterViewOrthoViewsWithExtraDims:
-    """Centering has to reach the orthogonal views when the viewer carries more
-    dimensions than the tracks, and has to survive a roll of the dim order.
+class TestOrthoViewsWithExtraDims:
+    """Centering has to reach the orthogonal views when the viewer carries more dimensions
+     than the tracks, and survive a roll.
 
-    The ortho views sync on `dims.point`, which is indexed by world axis, so the
-    sync itself is dimension- and order-agnostic. These tests pin that.
+    The ortho views sync on dims.point, indexed by world axis, so the sync is dimension-
+     and order-agnostic.
     """
 
-    def _setup(self, viewer, qtbot, tmp_path, extra_shape=None):
+    def test_centering_reaches_the_ortho_views(self, viewer, qtbot, tmp_path):
         ortho_manager = initialize_ortho_views(viewer)
         graph = _make_single_node_graph(
             tmp_path,
@@ -571,74 +495,28 @@ class TestCenterViewOrthoViewsWithExtraDims:
 
         tracks_viewer = TracksViewer.get_instance(viewer)
         tracks_viewer.update_tracks(tracks=tracks, name="test")
+        viewer.add_image(np.zeros((3, 2, 20, 20, 20), dtype=np.uint8), name="chan")
         qtbot.wait(50)
-
-        if extra_shape is not None:
-            viewer.add_image(np.zeros(extra_shape, dtype=np.uint8), name="channels")
-            qtbot.wait(50)
-
-        return ortho_manager, tracks_viewer
-
-    def test_centering_reaches_the_ortho_views_with_an_extra_dimension(
-        self, viewer, qtbot, tmp_path
-    ):
-        ortho_manager, tracks_viewer = self._setup(
-            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
-        )
         assert viewer.dims.ndim == 5
 
-        tracks_viewer.tracking_layers.center_view(node=1)
-        qtbot.wait(50)
-
         right = ortho_manager.right_widget.vm_container.viewer_model
         bottom = ortho_manager.bottom_widget.vm_container.viewer_model
-        expected = (0.0, 5.0, 10.0, 10.0)
-        assert tuple(viewer.dims.point[1:]) == expected
-        assert tuple(right.dims.point[1:]) == expected
-        assert tuple(bottom.dims.point[1:]) == expected
 
-        ortho_manager.cleanup()
-
-    def test_centering_reaches_the_ortho_views_after_a_roll(
-        self, viewer, qtbot, tmp_path
-    ):
-        """A roll permutes dims.order only, so the world-indexed point sync is
-        unaffected and the node still lands in every view."""
-
-        ortho_manager, tracks_viewer = self._setup(
-            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
-        )
-        viewer.dims.roll()
-        qtbot.wait(50)
-
-        tracks_viewer.tracking_layers.center_view(node=1)
-        qtbot.wait(50)
-
-        right = ortho_manager.right_widget.vm_container.viewer_model
-        bottom = ortho_manager.bottom_widget.vm_container.viewer_model
-        expected = (0.0, 5.0, 10.0, 10.0)
-        assert tuple(viewer.dims.point[1:]) == expected
-        assert tuple(right.dims.point[1:]) == expected
-        assert tuple(bottom.dims.point[1:]) == expected
-
-        ortho_manager.cleanup()
-
-    def test_the_extra_axis_is_not_moved_by_the_ortho_sync(
-        self, viewer, qtbot, tmp_path
-    ):
-        ortho_manager, tracks_viewer = self._setup(
-            viewer, qtbot, tmp_path, extra_shape=(3, 2, 20, 20, 20)
-        )
+        # the user is on channel 2, and centering leaves them there in every view
         point = list(viewer.dims.point)
         point[0] = 2.0
         viewer.dims.point = point
         qtbot.wait(50)
 
-        tracks_viewer.tracking_layers.center_view(node=1)
-        qtbot.wait(50)
+        for _ in range(2):  # before and after a roll
+            tracks_viewer.tracking_layers.center_view(node=1)
+            qtbot.wait(50)
 
-        right = ortho_manager.right_widget.vm_container.viewer_model
-        assert viewer.dims.point[0] == 2.0
-        assert right.dims.point[0] == 2.0
+            for model in (viewer, right, bottom):
+                assert tuple(model.dims.point[1:]) == (0.0, 5.0, 10.0, 10.0)
+                assert model.dims.point[0] == 2.0
+
+            viewer.dims.roll()
+            qtbot.wait(50)
 
         ortho_manager.cleanup()

--- a/tests/data_views/test_dims_utils.py
+++ b/tests/data_views/test_dims_utils.py
@@ -1,0 +1,209 @@
+"""Tests for relating tracks axes to viewer axes.
+
+The first class pins the napari behaviour the whole design rests on. If napari
+ever changes how it aligns layers to the viewer, or starts reindexing
+``dims.point`` on a roll, these fail first and say so directly, rather than
+leaving the plugin to misbehave somewhere far away.
+"""
+
+import numpy as np
+import pytest
+from napari.components.dims import Dims
+from napari.layers.base.base import _LayerSlicingState
+
+from motile_tracker.data_views.dims_utils import TracksDims, world_to_layer_axis
+
+
+class TestNapariDimsInvariants:
+    """The napari guarantees TracksDims is built on."""
+
+    def test_layers_align_on_their_trailing_dimensions(self):
+        """A 3-dim layer in a 4-dim viewer spans world axes 1, 2, 3 and not 0."""
+
+        assert list(_LayerSlicingState._world_to_layer_dims_impl([0], 4, 3)) == []
+        for world_axis, layer_axis in ((1, 0), (2, 1), (3, 2)):
+            assert list(
+                _LayerSlicingState._world_to_layer_dims_impl([world_axis], 4, 3)
+            ) == [layer_axis]
+
+    def test_roll_and_transpose_leave_point_alone(self):
+        """dims.point stays indexed by world axis; only `order` is permuted.
+
+        This is why the tracks-to-world map does not have to be remembered
+        across a roll: a roll does not move any axis to a different world index.
+        """
+
+        dims = Dims(ndim=4, ndisplay=2)
+        dims.range = ((0, 2, 1), (0, 10, 1), (0, 100, 1), (0, 100, 1))
+        dims.point = (1.0, 3.0, 50.0, 60.0)
+
+        dims.roll()
+        assert tuple(dims.point) == (1.0, 3.0, 50.0, 60.0)
+        assert dims.order != (0, 1, 2, 3)
+
+        dims.transpose()
+        assert tuple(dims.point) == (1.0, 3.0, 50.0, 60.0)
+
+    def test_rolling_can_put_a_non_tracks_axis_on_screen(self):
+        """Two rolls of a 4-dim viewer display world axes 0 and 1.
+
+        With 2D+time tracks behind a channel axis, axis 0 is the channel, so
+        code reading `dims.displayed` cannot assume it got a tracks axis.
+        """
+
+        dims = Dims(ndim=4, ndisplay=2)
+        dims.range = ((0, 2, 1), (0, 10, 1), (0, 100, 1), (0, 100, 1))
+
+        displayed = []
+        for _ in range(4):
+            displayed.append(dims.displayed)
+            dims.roll()
+
+        assert (0, 1) in displayed
+
+    def test_growing_ndim_prepends_and_keeps_the_tracks_on_the_tail(self):
+        """Adding a bigger layer pads dims.point at the front, not the back."""
+
+        dims = Dims(ndim=3, ndisplay=2)
+        dims.range = ((0, 10, 1), (0, 100, 1), (0, 100, 1))
+        dims.point = (3.0, 50.0, 60.0)
+
+        dims.ndim = 4
+
+        assert tuple(dims.point) == (0.0, 3.0, 50.0, 60.0)
+
+
+class TestWorldToLayerAxis:
+    def test_maps_trailing_axes(self):
+        assert world_to_layer_axis(1, 4, 3) == 0
+        assert world_to_layer_axis(3, 4, 3) == 2
+
+    def test_returns_none_for_an_axis_the_layer_does_not_span(self):
+        """The guard that matters: without it this is -1, which numpy wraps."""
+
+        assert world_to_layer_axis(0, 4, 3) is None
+
+    def test_returns_none_above_the_layers_range(self):
+        assert world_to_layer_axis(4, 4, 3) is None
+
+    def test_is_the_identity_when_the_dimensions_match(self):
+        for axis in range(3):
+            assert world_to_layer_axis(axis, 3, 3) == axis
+
+    def test_agrees_with_napari(self):
+        """Cross-check against napari's own implementation."""
+
+        for ndim_world in range(2, 6):
+            for ndim_layer in range(2, ndim_world + 1):
+                for world_axis in range(ndim_world):
+                    napari_result = list(
+                        _LayerSlicingState._world_to_layer_dims_impl(
+                            [world_axis], ndim_world, ndim_layer
+                        )
+                    )
+                    ours = world_to_layer_axis(world_axis, ndim_world, ndim_layer)
+                    assert ours == (napari_result[0] if napari_result else None)
+
+
+class TestTracksDims:
+    def test_no_extra_dimensions(self):
+        dims = TracksDims(ndim_world=3, ndim_tracks=3)
+
+        assert dims.offset == 0
+        assert dims.extra_axes == ()
+        assert dims.world_axes == (0, 1, 2)
+        assert dims.time_axis == 0
+        assert dims.spatial_axes == (1, 2)
+
+    def test_one_extra_dimension(self):
+        """2D+time tracks behind a channel axis."""
+
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        assert dims.offset == 1
+        assert dims.extra_axes == (0,)
+        assert dims.world_axes == (1, 2, 3)
+        assert dims.time_axis == 1
+        assert dims.spatial_axes == (2, 3)
+
+    def test_is_tracks_axis(self):
+        dims = TracksDims(ndim_world=5, ndim_tracks=3)
+
+        assert not dims.is_tracks_axis(0)
+        assert not dims.is_tracks_axis(1)
+        assert dims.is_tracks_axis(2)
+        assert dims.is_tracks_axis(4)
+        assert not dims.is_tracks_axis(5)
+
+    def test_to_world_and_back(self):
+        dims = TracksDims(ndim_world=5, ndim_tracks=4)
+
+        for tracks_axis in range(4):
+            world_axis = dims.to_world(tracks_axis)
+            assert dims.to_tracks(world_axis) == tracks_axis
+
+    def test_to_tracks_is_none_for_an_extra_axis(self):
+        assert TracksDims(ndim_world=4, ndim_tracks=3).to_tracks(0) is None
+
+    def test_to_world_rejects_an_axis_the_tracks_do_not_have(self):
+        with pytest.raises(IndexError):
+            TracksDims(ndim_world=4, ndim_tracks=3).to_world(3)
+
+    def test_rejects_a_viewer_smaller_than_the_tracks(self):
+        with pytest.raises(ValueError, match="fewer dimensions"):
+            TracksDims(ndim_world=3, ndim_tracks=4)
+
+    def test_rejects_degenerate_tracks(self):
+        with pytest.raises(ValueError, match="at least a time"):
+            TracksDims(ndim_world=4, ndim_tracks=1)
+
+
+class TestEmbedPoint:
+    def test_fills_the_tracks_axes_and_keeps_the_extra_ones(self):
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        embedded = dims.embed_point(
+            location=[5.0, 60.0, 70.0], point=[1.0, 0.0, 0.0, 0.0]
+        )
+
+        # the channel the user is on is preserved, the tracks axes are replaced
+        assert embedded == [1.0, 5.0, 60.0, 70.0]
+
+    def test_is_a_plain_copy_when_the_dimensions_match(self):
+        dims = TracksDims(ndim_world=3, ndim_tracks=3)
+
+        assert dims.embed_point([5.0, 60.0, 70.0], [0.0, 0.0, 0.0]) == [
+            5.0,
+            60.0,
+            70.0,
+        ]
+
+    def test_accepts_a_numpy_location(self):
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        embedded = dims.embed_point(np.array([5.0, 60.0, 70.0]), (2.0, 0.0, 0.0, 0.0))
+
+        assert embedded == [2.0, 5.0, 60.0, 70.0]
+
+    def test_rejects_a_location_of_the_wrong_length(self):
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        with pytest.raises(ValueError, match="expected 3"):
+            dims.embed_point([5.0, 60.0], [0.0] * 4)
+
+    def test_rejects_a_point_of_the_wrong_length(self):
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        with pytest.raises(ValueError, match="expected 4"):
+            dims.embed_point([5.0, 60.0, 70.0], [0.0] * 3)
+
+
+class TestTake:
+    def test_takes_the_trailing_values(self):
+        dims = TracksDims(ndim_world=4, ndim_tracks=3)
+
+        assert dims.take([1, 5, 60, 70]) == (5, 60, 70)
+
+    def test_rejects_the_wrong_length(self):
+        with pytest.raises(ValueError, match="Expected 4 values"):
+            TracksDims(ndim_world=4, ndim_tracks=3).take([1, 2, 3])

--- a/tests/data_views/test_dims_utils.py
+++ b/tests/data_views/test_dims_utils.py
@@ -6,7 +6,6 @@ ever changes how it aligns layers to the viewer, or starts reindexing
 leaving the plugin to misbehave somewhere far away.
 """
 
-import numpy as np
 import pytest
 from napari.components.dims import Dims
 from napari.layers.base.base import _LayerSlicingState
@@ -17,20 +16,11 @@ from motile_tracker.data_views.dims_utils import TracksDims, world_to_layer_axis
 class TestNapariDimsInvariants:
     """The napari guarantees TracksDims is built on."""
 
-    def test_layers_align_on_their_trailing_dimensions(self):
-        """A 3-dim layer in a 4-dim viewer spans world axes 1, 2, 3 and not 0."""
-
-        assert list(_LayerSlicingState._world_to_layer_dims_impl([0], 4, 3)) == []
-        for world_axis, layer_axis in ((1, 0), (2, 1), (3, 2)):
-            assert list(
-                _LayerSlicingState._world_to_layer_dims_impl([world_axis], 4, 3)
-            ) == [layer_axis]
-
     def test_roll_and_transpose_leave_point_alone(self):
         """dims.point stays indexed by world axis; only `order` is permuted.
 
-        This is why the tracks-to-world map does not have to be remembered
-        across a roll: a roll does not move any axis to a different world index.
+        This is why the tracks-to-world map does not have to be remembered across
+        a roll: a roll does not move any axis to a different world index.
         """
 
         dims = Dims(ndim=4, ndisplay=2)
@@ -47,8 +37,8 @@ class TestNapariDimsInvariants:
     def test_rolling_can_put_a_non_tracks_axis_on_screen(self):
         """Two rolls of a 4-dim viewer display world axes 0 and 1.
 
-        With 2D+time tracks behind a channel axis, axis 0 is the channel, so
-        code reading `dims.displayed` cannot assume it got a tracks axis.
+        With 2D+time tracks behind a channel axis, axis 0 is the channel, so code
+        reading `dims.displayed` cannot assume it got a tracks axis.
         """
 
         dims = Dims(ndim=4, ndisplay=2)
@@ -74,24 +64,8 @@ class TestNapariDimsInvariants:
 
 
 class TestWorldToLayerAxis:
-    def test_maps_trailing_axes(self):
-        assert world_to_layer_axis(1, 4, 3) == 0
-        assert world_to_layer_axis(3, 4, 3) == 2
-
-    def test_returns_none_for_an_axis_the_layer_does_not_span(self):
-        """The guard that matters: without it this is -1, which numpy wraps."""
-
-        assert world_to_layer_axis(0, 4, 3) is None
-
-    def test_returns_none_above_the_layers_range(self):
-        assert world_to_layer_axis(4, 4, 3) is None
-
-    def test_is_the_identity_when_the_dimensions_match(self):
-        for axis in range(3):
-            assert world_to_layer_axis(axis, 3, 3) == axis
-
     def test_agrees_with_napari(self):
-        """Cross-check against napari's own implementation."""
+        """Cross-check the trailing alignment against napari's own version."""
 
         for ndim_world in range(2, 6):
             for ndim_layer in range(2, ndim_world + 1):
@@ -104,106 +78,86 @@ class TestWorldToLayerAxis:
                     ours = world_to_layer_axis(world_axis, ndim_world, ndim_layer)
                     assert ours == (napari_result[0] if napari_result else None)
 
+    @pytest.mark.parametrize(
+        ("world_axis", "expected"),
+        [(0, None), (1, 0), (3, 2), (4, None)],
+    )
+    def test_is_none_outside_the_layers_own_axes(self, world_axis, expected):
+        """The guard that matters: without it a leading axis gives -1, which numpy
+        silently wraps to the wrong end instead of raising."""
+
+        assert world_to_layer_axis(world_axis, 4, 3) == expected
+
 
 class TestTracksDims:
-    def test_no_extra_dimensions(self):
-        dims = TracksDims(ndim_world=3, ndim_tracks=3)
+    @pytest.mark.parametrize(
+        ("ndim_world", "offset", "extra", "world_axes", "time", "spatial"),
+        [
+            (3, 0, (), (0, 1, 2), 0, (1, 2)),
+            (4, 1, (0,), (1, 2, 3), 1, (2, 3)),
+            (5, 2, (0, 1), (2, 3, 4), 2, (3, 4)),
+        ],
+    )
+    def test_axis_bookkeeping(
+        self, ndim_world, offset, extra, world_axes, time, spatial
+    ):
+        dims = TracksDims(ndim_world=ndim_world, ndim_tracks=3)
 
-        assert dims.offset == 0
-        assert dims.extra_axes == ()
-        assert dims.world_axes == (0, 1, 2)
-        assert dims.time_axis == 0
-        assert dims.spatial_axes == (1, 2)
+        assert dims.offset == offset
+        assert dims.extra_axes == extra
+        assert dims.world_axes == world_axes
+        assert dims.time_axis == time
+        assert dims.spatial_axes == spatial
+        assert not any(dims.is_tracks_axis(axis) for axis in extra)
+        assert all(dims.is_tracks_axis(axis) for axis in world_axes)
+        assert not dims.is_tracks_axis(ndim_world)
 
-    def test_one_extra_dimension(self):
-        """2D+time tracks behind a channel axis."""
-
-        dims = TracksDims(ndim_world=4, ndim_tracks=3)
-
-        assert dims.offset == 1
-        assert dims.extra_axes == (0,)
-        assert dims.world_axes == (1, 2, 3)
-        assert dims.time_axis == 1
-        assert dims.spatial_axes == (2, 3)
-
-    def test_is_tracks_axis(self):
-        dims = TracksDims(ndim_world=5, ndim_tracks=3)
-
-        assert not dims.is_tracks_axis(0)
-        assert not dims.is_tracks_axis(1)
-        assert dims.is_tracks_axis(2)
-        assert dims.is_tracks_axis(4)
-        assert not dims.is_tracks_axis(5)
-
-    def test_to_world_and_back(self):
+    def test_axes_round_trip(self):
         dims = TracksDims(ndim_world=5, ndim_tracks=4)
 
         for tracks_axis in range(4):
-            world_axis = dims.to_world(tracks_axis)
-            assert dims.to_tracks(world_axis) == tracks_axis
-
-    def test_to_tracks_is_none_for_an_extra_axis(self):
-        assert TracksDims(ndim_world=4, ndim_tracks=3).to_tracks(0) is None
-
-    def test_to_world_rejects_an_axis_the_tracks_do_not_have(self):
+            assert dims.to_tracks(dims.to_world(tracks_axis)) == tracks_axis
+        assert dims.to_tracks(0) is None
         with pytest.raises(IndexError):
-            TracksDims(ndim_world=4, ndim_tracks=3).to_world(3)
+            dims.to_world(4)
 
-    def test_rejects_a_viewer_smaller_than_the_tracks(self):
-        with pytest.raises(ValueError, match="fewer dimensions"):
-            TracksDims(ndim_world=3, ndim_tracks=4)
+    @pytest.mark.parametrize(
+        ("ndim_world", "ndim_tracks", "match"),
+        [(3, 4, "fewer dimensions"), (4, 1, "at least a time")],
+    )
+    def test_rejects_impossible_combinations(self, ndim_world, ndim_tracks, match):
+        with pytest.raises(ValueError, match=match):
+            TracksDims(ndim_world=ndim_world, ndim_tracks=ndim_tracks)
 
-    def test_rejects_degenerate_tracks(self):
-        with pytest.raises(ValueError, match="at least a time"):
-            TracksDims(ndim_world=4, ndim_tracks=1)
-
-
-class TestEmbedPoint:
-    def test_fills_the_tracks_axes_and_keeps_the_extra_ones(self):
+    def test_embed_point_fills_the_tail_and_keeps_the_extra_axes(self):
         dims = TracksDims(ndim_world=4, ndim_tracks=3)
 
-        embedded = dims.embed_point(
-            location=[5.0, 60.0, 70.0], point=[1.0, 0.0, 0.0, 0.0]
-        )
-
         # the channel the user is on is preserved, the tracks axes are replaced
-        assert embedded == [1.0, 5.0, 60.0, 70.0]
-
-    def test_is_a_plain_copy_when_the_dimensions_match(self):
-        dims = TracksDims(ndim_world=3, ndim_tracks=3)
-
-        assert dims.embed_point([5.0, 60.0, 70.0], [0.0, 0.0, 0.0]) == [
+        assert dims.embed_point([5.0, 60.0, 70.0], [1.0, 0.0, 0.0, 0.0]) == [
+            1.0,
+            5.0,
+            60.0,
+            70.0,
+        ]
+        # and it is a plain copy when there are no extra axes
+        no_extra = TracksDims(ndim_world=3, ndim_tracks=3)
+        assert no_extra.embed_point([5.0, 60.0, 70.0], [0.0] * 3) == [
             5.0,
             60.0,
             70.0,
         ]
 
-    def test_accepts_a_numpy_location(self):
-        dims = TracksDims(ndim_world=4, ndim_tracks=3)
-
-        embedded = dims.embed_point(np.array([5.0, 60.0, 70.0]), (2.0, 0.0, 0.0, 0.0))
-
-        assert embedded == [2.0, 5.0, 60.0, 70.0]
-
-    def test_rejects_a_location_of_the_wrong_length(self):
+    def test_embed_point_rejects_wrong_lengths(self):
         dims = TracksDims(ndim_world=4, ndim_tracks=3)
 
         with pytest.raises(ValueError, match="expected 3"):
             dims.embed_point([5.0, 60.0], [0.0] * 4)
-
-    def test_rejects_a_point_of_the_wrong_length(self):
-        dims = TracksDims(ndim_world=4, ndim_tracks=3)
-
         with pytest.raises(ValueError, match="expected 4"):
             dims.embed_point([5.0, 60.0, 70.0], [0.0] * 3)
 
-
-class TestTake:
-    def test_takes_the_trailing_values(self):
+    def test_take_reads_the_tracks_part_of_a_world_indexed_sequence(self):
         dims = TracksDims(ndim_world=4, ndim_tracks=3)
 
         assert dims.take([1, 5, 60, 70]) == (5, 60, 70)
-
-    def test_rejects_the_wrong_length(self):
         with pytest.raises(ValueError, match="Expected 4 values"):
-            TracksDims(ndim_world=4, ndim_tracks=3).take([1, 2, 3])
+            dims.take([1, 2, 3])


### PR DESCRIPTION
The Viewer may have more dimensions than the Tracks, e.g. when a multichannel layer is present. 
This adds a helper property to know where the tracks dimensions are in the Viewer dimensions, so that it does not crash when centering on a node due to a missing dimension. The 'center on node' functionality should also skip situations in which the 'extra' axis is rolled on the screen.

Closes https://github.com/live-image-tracking-tools/napari-track-edit/issues/506