### PR TITLE
Add wgpu dependency to the workflow that only runs on main

### DIFF
--- a/.github/workflows/benchmark-report.yml
+++ b/.github/workflows/benchmark-report.yml
@@ -18,7 +18,23 @@ jobs:
       UV_NO_SYNC: "1"
     steps:
       - uses: actions/checkout@v7
+      # The Ubuntu runner image ships broken Microsoft apt repos whose signature
+      # is periodically invalid ("Clearsigned file isn't valid, got 'NOSPLIT'"),
+      # which fails the apt-get update inside setup-qt-libs. We don't need them.
+      - name: Remove broken Microsoft apt sources (ubuntu runner image)
+        run: |
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list \
+                     /etc/apt/sources.list.d/azure-cli.sources
       - uses: tlambert03/setup-qt-libs@v1
+
+      # wgpu (via pygfx/fastplotlib, used by the tree view) needs a real Vulkan/GL
+      # adapter; Xvfb (below) only provides X11/GLX, not Vulkan. lavapipe/llvmpipe
+      # give it a software one, matching how pygfx/wgpu-py run their own Linux CI.
+      - name: Install llvmpipe and lavapipe for offscreen wgpu rendering
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get install -y libegl1-mesa-dev libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Set up Python
         uses: astral-sh/setup-uv@v7

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ test:
     uv run pytest .
 
 start:
-    uv run motile_tracker
+    uv run --extra gurobipy13 motile_tracker
 
 [working-directory: 'docs']
 @docs-build:

--- a/src/motile_tracker/__main__.py
+++ b/src/motile_tracker/__main__.py
@@ -2,8 +2,24 @@ import argparse
 import sys
 
 import napari
+import logging
 
 from motile_tracker.application_menus.main_app import StartupWidget
+
+
+def _activate_on_macos(viewer: napari.Viewer) -> None:
+    """Force the napari window (and its menu bar) to take focus on macOS.
+
+    When napari is launched as a subprocess of another app (e.g. VS Code's
+    integrated terminal), the OS sometimes leaves the parent app's menu bar
+    in place even though napari's window is frontmost. Explicitly raising
+    and activating the window nudges macOS into handing over the menu bar.
+    """
+    if sys.platform != "darwin":
+        return
+    window = viewer.window._qt_window
+    window.raise_()
+    window.activateWindow()
 
 
 def main():
@@ -18,9 +34,16 @@ def main():
 
     viewer = napari.Viewer()
     StartupWidget(viewer, mode=args.mode)
+    _activate_on_macos(viewer)
 
     napari.run()
 
 
 if __name__ == "__main__":
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(filename)s:%(lineno)d] %(levelname)-8s %(message)s",
+    )
+    logging.getLogger("motile_tracker").setLevel(logging.DEBUG)
     sys.exit(main())


### PR DESCRIPTION
I also lumped in some other stuff.... specifically some improvements to the experience when running "just start" (include gurobi, force the macos menu bar to update).