### PR TITLE
autodetect t for time field

### DIFF
--- a/src/motile_tracker/__main__.py
+++ b/src/motile_tracker/__main__.py
@@ -1,8 +1,8 @@
 import argparse
+import logging
 import sys
 
 import napari
-import logging
 
 from motile_tracker.application_menus.main_app import StartupWidget
 
@@ -40,7 +40,6 @@ def main():
 
 
 if __name__ == "__main__":
-
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s [%(filename)s:%(lineno)d] %(levelname)-8s %(message)s",

--- a/src/motile_tracker/import_export/menus/prop_map_widget.py
+++ b/src/motile_tracker/import_export/menus/prop_map_widget.py
@@ -28,6 +28,18 @@ from motile_tracker.import_export.menus.geff_import_utils import (
     geff_group_path,
 )
 
+# Names a column may go by, per standard field. Checked before fuzzy matching,
+# which cannot be trusted to find them: "time" scores 0.50 against "frontier"
+# but only 0.40 against "t", the name every funtracks graph uses.
+FIELD_ALIASES = {
+    "time": ("t", "frame"),
+    DEFAULT_TRACKLET_KEY: ("track_id",),
+    "id": ("node_id",),
+}
+
+# column names in the loaded file that should not be fuzzily matched
+EXACT_ONLY_PROPS = {"id", "node_id", "parent_id"}
+
 
 def get_attr_dtype_zarr(root: zarr.Group, attr: str) -> str:
     """
@@ -263,6 +275,18 @@ class StandardFieldMapWidget(QWidget):
                 mapping[attribute] = attribute
                 self.props_left.remove(attribute)
 
+        # then by a known alias, before any fuzzy matching gets the chance to
+        # prefer a coincidentally longer name
+        for attribute in self.standard_fields:
+            if attribute in mapping:
+                continue
+            lower_map = {p.lower(): p for p in self.props_left}
+            for alias in FIELD_ALIASES.get(attribute, ()):
+                if alias in lower_map:
+                    mapping[attribute] = lower_map[alias]
+                    self.props_left.remove(lower_map[alias])
+                    break
+
         # assign closest remaining column as best guess for remaining standard fields
         for attribute in self.standard_fields:
             if attribute in mapping:
@@ -274,7 +298,11 @@ class StandardFieldMapWidget(QWidget):
                 mapping[attribute] = "None"
                 continue
             if len(self.props_left) > 0:
-                lower_map = {p.lower(): p for p in self.props_left}
+                lower_map = {
+                    p.lower(): p
+                    for p in self.props_left
+                    if p.lower() not in EXACT_ONLY_PROPS
+                }
                 closest = difflib.get_close_matches(
                     attribute.lower(), lower_map.keys(), n=1, cutoff=0.4
                 )

--- a/tests/import_export/test_import_dialog.py
+++ b/tests/import_export/test_import_dialog.py
@@ -6,6 +6,7 @@ segmentation inclusion.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import numpy as np
@@ -21,6 +22,7 @@ from funtracks.import_export import (
 )
 
 from motile_tracker.import_export.menus.import_dialog import ImportDialog
+from motile_tracker.import_export.menus.prop_map_widget import StandardFieldMapWidget
 from motile_tracker.motile.backend.motile_run import MotileRun
 from motile_tracker.motile.backend.solver_params import SolverParams
 
@@ -130,6 +132,59 @@ def test_import_dialog_csv(qtbot, small_csv, dim_3d, include_seg):
             assert optional["area"]["recompute"].isEnabled() is True
         else:
             assert optional["area"]["recompute"].isEnabled() is False
+
+
+class TestInitialFieldMapping:
+    """Guessing which column is which, before the user corrects it."""
+
+    PROPS = [
+        "parent_id",
+        "area",
+        "solution",
+        "z",
+        "mask",
+        "t",
+        "frontier",
+        "bbox",
+        "y",
+        "x",
+    ]
+
+    def _mapping(self, props: list[str]) -> dict[str, str]:
+        """Call the guesser without building a widget (it needs no Qt)."""
+        state = SimpleNamespace(
+            node_attrs=props,
+            metadata={},
+            standard_fields=[
+                "time",
+                "z",
+                "y",
+                "x",
+                "seg_id",
+                "tracklet_id",
+                "lineage_id",
+            ],
+        )
+        return StandardFieldMapWidget._get_initial_mapping(state)
+
+    def test_time_is_taken_from_t(self):
+        """ "t" is what every funtracks graph calls time, and fuzzy matching misses it.
+
+        "time" scores 0.50 against "frontier" and only 0.40 against "t", so
+        without the alias the guess lands on an unrelated float column and the
+        import fails on the -1.0 values in it.
+        """
+        assert self._mapping(self.PROPS)["time"] == "t"
+
+    def test_parent_id_is_not_guessed_as_a_track_id(self):
+        """It points at another node, but scores 0.60 against "tracklet_id"."""
+        mapping = self._mapping(self.PROPS)
+
+        assert mapping["tracklet_id"] == "None"
+        assert mapping["lineage_id"] == "None"
+
+    def test_a_real_track_id_is_still_found(self):
+        assert self._mapping([*self.PROPS, "track_id"])["tracklet_id"] == "track_id"
 
 
 class TestPropMapWidgetKeys:


### PR DESCRIPTION
The dialog now knows that a column called `t` means time (and `track_id` means tracklet id), so it picks those instead of guessing by which name merely *looks* similar.

And it never guesses `parent_id`, `id`, or `node_id` into some other field — those only get used when the name matches exactly, or when you pick them yourself.
